### PR TITLE
Bug fix and new alabama income for 2018

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 build
 shapes
 vendor
+
+.idea/

--- a/src/Countries/US/Alabama/AlabamaIncome/V20170101/AlabamaIncome.php
+++ b/src/Countries/US/Alabama/AlabamaIncome/V20170101/AlabamaIncome.php
@@ -80,7 +80,7 @@ class AlabamaIncome extends BaseAlabamaIncome
 
     public function getAdjustedEarnings()
     {
-        $adjusted_earnings = (($this->payroll->earnings - $this->payroll->supplemental_earnings) * $this->payroll->pay_periods) - ($this->federal_income_tax * $this->payroll->pay_periods);
+        $adjusted_earnings = ($this->payroll->earnings * $this->payroll->pay_periods) - ($this->federal_income_tax * $this->payroll->pay_periods);
 
         if ($this->tax_information->filing_status != static::FILING_ZERO) {
             $adjusted_earnings = $adjusted_earnings - $this->getStandardDeduction() - $this->getPersonalExemptionAllowance() - $this->getDependentExemption();
@@ -91,14 +91,14 @@ class AlabamaIncome extends BaseAlabamaIncome
 
     public function getDependentExemption()
     {
-        $gross_earnings = ($this->payroll->earnings - $this->payroll->supplemental_earnings) * $this->payroll->pay_periods;
+        $gross_earnings = $this->payroll->earnings * $this->payroll->pay_periods;
         $dependent_exemption = $this->getTaxBracket($gross_earnings, static::DEPENDENT_EXEMPTION_BRACKETS);
         return $dependent_exemption[1] * $this->tax_information->dependents;
     }
 
     public function getStandardDeduction()
     {
-        $gross_earnings = ($this->payroll->earnings - $this->payroll->supplemental_earnings) * $this->payroll->pay_periods;
+        $gross_earnings = $this->payroll->earnings * $this->payroll->pay_periods;
         $standard_deduction = static::STANDARD_DEDUCTIONS[$this->tax_information->filing_status];
         $deduction = $standard_deduction['amount'];
 

--- a/src/Countries/US/Alabama/AlabamaIncome/V20170101/AlabamaIncome.php
+++ b/src/Countries/US/Alabama/AlabamaIncome/V20170101/AlabamaIncome.php
@@ -27,6 +27,7 @@ class AlabamaIncome extends BaseAlabamaIncome
         self::FILING_SINGLE => [
             'base' => 20499.99,
             'amount' => 2500,
+            'floor' => 2000,
             'modifier' => [
                 'amount' => 25,
                 'per' => 500,
@@ -35,6 +36,7 @@ class AlabamaIncome extends BaseAlabamaIncome
         self::FILING_SEPERATE => [
             'base' => 10249.99,
             'amount' => 3750,
+            'floor' => 2000,
             'modifier' => [
                 'amount' => 88,
                 'per' => 250,
@@ -43,6 +45,7 @@ class AlabamaIncome extends BaseAlabamaIncome
         self::FILING_MARRIED => [
             'base' => 20499.99,
             'amount' => 7500,
+            'floor' => 4000,
             'modifier' => [
                 'amount' => 175,
                 'per' => 500,
@@ -51,6 +54,7 @@ class AlabamaIncome extends BaseAlabamaIncome
         self::FILING_HEAD_OF_HOUSEHOLD => [
             'base' => 20499.99,
             'amount' => 4700,
+            'floor' => 2000,
             'modifier' => [
                 'amount' => 135,
                 'per' => 500,
@@ -106,7 +110,7 @@ class AlabamaIncome extends BaseAlabamaIncome
             $deduction -= $standard_deduction['modifier']['amount'] * ceil(($gross_earnings - $standard_deduction['base']) / $standard_deduction['modifier']['per']);
         }
 
-        return $deduction;
+        return $deduction < $standard_deduction['floor'] ? $standard_deduction['floor'] : $deduction;
     }
 
     public function getPersonalExemptionAllowance()

--- a/src/Countries/US/Alabama/AlabamaIncome/V20180101/AlabamaIncome.php
+++ b/src/Countries/US/Alabama/AlabamaIncome/V20180101/AlabamaIncome.php
@@ -80,7 +80,7 @@ class AlabamaIncome extends BaseAlabamaIncome
 
     public function getAdjustedEarnings()
     {
-        $adjusted_earnings = (($this->payroll->earnings - $this->payroll->supplemental_earnings) * $this->payroll->pay_periods) - ($this->federal_income_tax * $this->payroll->pay_periods);
+        $adjusted_earnings = ($this->payroll->earnings * $this->payroll->pay_periods) - ($this->federal_income_tax * $this->payroll->pay_periods);
 
         if ($this->tax_information->filing_status != static::FILING_ZERO) {
             $adjusted_earnings = $adjusted_earnings - $this->getStandardDeduction() - $this->getPersonalExemptionAllowance() - $this->getDependentExemption();
@@ -91,14 +91,14 @@ class AlabamaIncome extends BaseAlabamaIncome
 
     public function getDependentExemption()
     {
-        $gross_earnings = ($this->payroll->earnings - $this->payroll->supplemental_earnings) * $this->payroll->pay_periods;
+        $gross_earnings = $this->payroll->earnings * $this->payroll->pay_periods;
         $dependent_exemption = $this->getTaxBracket($gross_earnings, static::DEPENDENT_EXEMPTION_BRACKETS);
         return $dependent_exemption[1] * $this->tax_information->dependents;
     }
 
     public function getStandardDeduction()
     {
-        $gross_earnings = ($this->payroll->earnings - $this->payroll->supplemental_earnings) * $this->payroll->pay_periods;
+        $gross_earnings = $this->payroll->earnings * $this->payroll->pay_periods;
         $standard_deduction = static::STANDARD_DEDUCTIONS[$this->tax_information->filing_status];
         $deduction = $standard_deduction['amount'];
 

--- a/src/Countries/US/Alabama/AlabamaIncome/V20180101/AlabamaIncome.php
+++ b/src/Countries/US/Alabama/AlabamaIncome/V20180101/AlabamaIncome.php
@@ -27,6 +27,7 @@ class AlabamaIncome extends BaseAlabamaIncome
         self::FILING_SINGLE => [
             'base' => 20499.99,
             'amount' => 2500,
+            'floor' => 2000,
             'modifier' => [
                 'amount' => 25,
                 'per' => 500,
@@ -35,6 +36,7 @@ class AlabamaIncome extends BaseAlabamaIncome
         self::FILING_SEPERATE => [
             'base' => 10249.99,
             'amount' => 3750,
+            'floor' => 2000,
             'modifier' => [
                 'amount' => 88,
                 'per' => 250,
@@ -43,6 +45,7 @@ class AlabamaIncome extends BaseAlabamaIncome
         self::FILING_MARRIED => [
             'base' => 20499.99,
             'amount' => 7500,
+            'floor' => 4000,
             'modifier' => [
                 'amount' => 175,
                 'per' => 500,
@@ -51,6 +54,7 @@ class AlabamaIncome extends BaseAlabamaIncome
         self::FILING_HEAD_OF_HOUSEHOLD => [
             'base' => 20499.99,
             'amount' => 4700,
+            'floor' => 2000,
             'modifier' => [
                 'amount' => 135,
                 'per' => 500,
@@ -106,7 +110,7 @@ class AlabamaIncome extends BaseAlabamaIncome
             $deduction -= $standard_deduction['modifier']['amount'] * ceil(($gross_earnings - $standard_deduction['base']) / $standard_deduction['modifier']['per']);
         }
 
-        return $deduction;
+        return $deduction < $standard_deduction['floor'] ? $standard_deduction['floor'] : $deduction;
     }
 
     public function getPersonalExemptionAllowance()

--- a/src/Countries/US/Alabama/AlabamaIncome/V20180101/AlabamaIncome.php
+++ b/src/Countries/US/Alabama/AlabamaIncome/V20180101/AlabamaIncome.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Appleton\Taxes\Countries\US\Alabama\AlabamaIncome\V20170101;
+namespace Appleton\Taxes\Countries\US\Alabama\AlabamaIncome\V20180101;
 
 use Appleton\Taxes\Classes\Payroll;
 use Appleton\Taxes\Countries\US\Alabama\AlabamaIncome\AlabamaIncome as BaseAlabamaIncome;

--- a/src/Countries/US/Alabama/AlabamaIncome/V20180101/AlabamaIncome.php
+++ b/src/Countries/US/Alabama/AlabamaIncome/V20180101/AlabamaIncome.php
@@ -34,7 +34,7 @@ class AlabamaIncome extends BaseAlabamaIncome
             ],
         ],
         self::FILING_SEPERATE => [
-            'base' => 10249.99,
+            'base' => 10749.99,
             'amount' => 3750,
             'floor' => 2000,
             'modifier' => [
@@ -43,7 +43,7 @@ class AlabamaIncome extends BaseAlabamaIncome
             ]
         ],
         self::FILING_MARRIED => [
-            'base' => 20499.99,
+            'base' => 23499.99,
             'amount' => 7500,
             'floor' => 4000,
             'modifier' => [

--- a/tests/Unit/TaxesTest.php
+++ b/tests/Unit/TaxesTest.php
@@ -36,7 +36,7 @@ class TaxesTest extends \TestCase
         $this->assertSame(0.97, $results->getTax(MedicareEmployer::class));
         $this->assertSame(4.13, $results->getTax(SocialSecurity::class));
         $this->assertSame(4.13, $results->getTax(SocialSecurityEmployer::class));
-        $this->assertSame(2.03, $results->getTax(AlabamaIncome::class));
+        $this->assertSame(2.37, $results->getTax(AlabamaIncome::class));
         $this->assertSame(1.80, $results->getTax(AlabamaUnemployment::class));
         $this->assertSame(0.67, $results->getTax(BirminghamOccupational::class));
     }
@@ -96,7 +96,7 @@ class TaxesTest extends \TestCase
         $this->assertSame(7.55, $results->getTax(FederalIncome::class));
         $this->assertSame(1.57, $results->getTax(Medicare::class));
         $this->assertSame(0.97, $results->getTax(MedicareEmployer::class));
-        $this->assertSame(2.03, $results->getTax(AlabamaIncome::class));
+        $this->assertSame(2.37, $results->getTax(AlabamaIncome::class));
         $this->assertSame(0.0, $results->getTax(AlabamaUnemployment::class));
         $this->assertSame(0.67, $results->getTax(BirminghamOccupational::class));
 
@@ -113,7 +113,7 @@ class TaxesTest extends \TestCase
         $this->assertSame(7.55, $results->getTax(FederalIncome::class));
         $this->assertSame(1.57, $results->getTax(Medicare::class));
         $this->assertSame(0.97, $results->getTax(MedicareEmployer::class));
-        $this->assertSame(2.03, $results->getTax(AlabamaIncome::class));
+        $this->assertSame(2.37, $results->getTax(AlabamaIncome::class));
         $this->assertSame(0.0, $results->getTax(AlabamaUnemployment::class));
         $this->assertSame(0.67, $results->getTax(BirminghamOccupational::class));
     }


### PR DESCRIPTION
Added 2018 alabama income tax, it’s identical to 2017…

Also, fixed some small bugs:

1. Finding the correct filing bracket could return the wrong bracket for filing separately. The way the brackets work out, all statuses except Married come back with the same numbers, that was changing an >= to an ===.

2. We need to take the ceiling of a calculation for calculating the standard deduction, because the increments are whole increments, not decimals. 

3. When calculating the standard deduction, the amount can only go so low, so I added a `floor` for each of these categories.