### PR TITLE
money-323 use default tax information

### DIFF
--- a/src/Providers/TaxInformationServiceProvider.php
+++ b/src/Providers/TaxInformationServiceProvider.php
@@ -27,7 +27,7 @@ class TaxInformationServiceProvider extends ServiceProvider
                     } else {
                         $tax_information = $interface::forUser($payroll->user)->first();
                         if (is_null($tax_information)) {
-                            throw new \Exception('The tax information for that user could not be loaded.');
+                            $tax_information = $interface::getDefault();
                         }
                     }
                 } else {

--- a/tests/Unit/Countries/US/Alabama/AlabamaIncomeTest.php
+++ b/tests/Unit/Countries/US/Alabama/AlabamaIncomeTest.php
@@ -119,4 +119,19 @@ class AlabamaIncomeTest extends \TestCase
 
         $this->assertSame(2.84, $results->getTax(AlabamaIncome::class));
     }
+
+    public function testAlabamaIncomeUseDefault()
+    {
+        AlabamaIncomeTaxInformation::forUser($this->user)->delete();
+
+        $results = $this->taxes->calculate(function ($taxes) {
+            $taxes->setHomeLocation($this->getLocation('us.alabama'));
+            $taxes->setWorkLocation($this->getLocation('us.alabama'));
+            $taxes->setUser($this->user);
+            $taxes->setEarnings(66.68);
+            $taxes->setPayPeriods(260);
+        });
+
+        $this->assertSame(2.07, $results->getTax(AlabamaIncome::class));
+    }
 }

--- a/tests/Unit/Countries/US/FederalIncomeTest.php
+++ b/tests/Unit/Countries/US/FederalIncomeTest.php
@@ -315,4 +315,19 @@ class FederalIncomeTest extends \TestCase
 
         $this->assertSame(64.64, $results->getTax(FederalIncome::class));
     }
+
+    public function testFederalIncomeUseDefault() {
+        FederalIncomeTaxInformation::forUser($this->user)->delete();
+
+        $results = $this->taxes->calculate(function ($taxes) {
+            $taxes->setHomeLocation($this->getLocation('us'));
+            $taxes->setWorkLocation($this->getLocation('us'));
+            $taxes->setUser($this->user);
+            $taxes->setEarnings(800);
+            $taxes->setPayPeriods(52);
+            $taxes->setDate($this->date('2018-01-01'));
+        });
+
+        $this->assertSame(83.8, $results->getTax(FederalIncome::class));
+    }
 }

--- a/tests/Unit/Countries/US/Georgia/GeorgiaIncomeTest.php
+++ b/tests/Unit/Countries/US/Georgia/GeorgiaIncomeTest.php
@@ -79,4 +79,30 @@ class GeorgiaIncomeTest extends \TestCase
 
         $this->assertSame(0.01, $results->getTax(GeorgiaIncome::class));
     }
+
+    public function testGeorgiaIncomeUseDefault()
+    {
+        GeorgiaIncomeTaxInformation::forUser($this->user)->delete();
+
+        $results = $this->taxes->calculate(function ($taxes) {
+            $taxes->setHomeLocation($this->getLocation('us.georgia'));
+            $taxes->setWorkLocation($this->getLocation('us.georgia'));
+            $taxes->setUser($this->user);
+            $taxes->setEarnings(0);
+            $taxes->setPayPeriods(260);
+        });
+
+        $this->assertSame(0.0, $results->getTax(GeorgiaIncome::class));
+
+        $results = $this->taxes->calculate(function ($taxes) {
+            $taxes->setHomeLocation($this->getLocation('us.georgia'));
+            $taxes->setWorkLocation($this->getLocation('us.georgia'));
+            $taxes->setUser($this->user);
+            $taxes->setEarnings(66.68);
+            $taxes->setPayPeriods(260);
+        });
+
+        $this->assertSame(2.74, $results->getTax(GeorgiaIncome::class));
+    }
+
 }


### PR DESCRIPTION
**Story**
https://github.com/spurjobs/Spur-Money-Inc/issues/323

**Description**
* use default tax information when none is found for a user