### PR TITLE
acc-191 remove type from class

### DIFF
--- a/src/Countries/US/Kentucky/JeffersonCounty/JeffersonCounty.php
+++ b/src/Countries/US/Kentucky/JeffersonCounty/JeffersonCounty.php
@@ -8,7 +8,6 @@ use Appleton\Taxes\Models\Countries\US\Kentucky\KentuckyIncomeTaxInformation;
 
 abstract class JeffersonCounty extends BaseLocalIncome
 {
-    const TYPE = 'local';
     const PRIORITY = 9999;
 
     public $tax_total = 0;

--- a/src/Countries/US/Kentucky/JeffersonCounty/JeffersonCounty.php
+++ b/src/Countries/US/Kentucky/JeffersonCounty/JeffersonCounty.php
@@ -8,8 +8,6 @@ use Appleton\Taxes\Models\Countries\US\Kentucky\KentuckyIncomeTaxInformation;
 
 abstract class JeffersonCounty extends BaseLocalIncome
 {
-    const PRIORITY = 9999;
-
     public $tax_total = 0;
 
     protected $tax_information;


### PR DESCRIPTION
refs: https://spurjob.atlassian.net/browse/ACC-191

Summary: Can't get the Jefferson County tax to show up in the local tax report on the payroll portal and noticed that Jefferson County was the only class that extends `BaseLocal` that has `const TYPE = 'local';` Not sure if this is the problem but it is the only thing I've come up with. 

I will redo the tag and release. 