### PR TITLE
feature/ACC-252 - Add 2019 CO taxes

### DIFF
--- a/src/Countries/US/Colorado/ColoradoIncome/ColoradoIncome.php
+++ b/src/Countries/US/Colorado/ColoradoIncome/ColoradoIncome.php
@@ -5,6 +5,7 @@ namespace Appleton\Taxes\Countries\US\Colorado\ColoradoIncome;
 use Appleton\Taxes\Classes\BaseStateIncome;
 use Appleton\Taxes\Classes\Payroll;
 use Appleton\Taxes\Models\Countries\US\Colorado\ColoradoIncomeTaxInformation;
+use Illuminate\Database\Eloquent\Collection;
 
 abstract class ColoradoIncome extends BaseStateIncome
 {
@@ -20,5 +21,44 @@ abstract class ColoradoIncome extends BaseStateIncome
     {
         parent::__construct($payroll);
         $this->tax_information = $tax_information;
+    }
+
+    abstract protected function getExemptionAmounts(): array;
+
+    abstract protected function getSingleBracket(): array;
+
+    abstract protected function getMarriedBracket(): array;
+
+    public function compute(Collection $tax_areas)
+    {
+        return round(parent::compute($tax_areas));
+    }
+
+    public function getAdjustedEarnings()
+    {
+        return $this->getGrossEarnings() - $this->getExemptionAllowance();
+    }
+
+    public function getSupplementalIncomeTax()
+    {
+        return 0;
+    }
+
+    public function getTaxBrackets(): array
+    {
+        return $this->tax_information->filing_status === static::FILING_MARRIED
+            ? $this->getMarriedBracket()
+            : $this->getSingleBracket();
+    }
+
+    private function getExemptionAllowance()
+    {
+        return array_get($this->getExemptionAmounts(), min($this->tax_information->exemptions, 10));
+    }
+
+    private function getGrossEarnings()
+    {
+        return ($this->payroll->getEarnings() - $this->payroll->getSupplementalEarnings())
+            * $this->payroll->pay_periods;
     }
 }

--- a/src/Countries/US/Colorado/ColoradoIncome/V20190101/ColoradoIncome.php
+++ b/src/Countries/US/Colorado/ColoradoIncome/V20190101/ColoradoIncome.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Appleton\Taxes\Countries\US\Colorado\ColoradoIncome\V20180101;
+namespace Appleton\Taxes\Countries\US\Colorado\ColoradoIncome\V20190101;
 
 use Appleton\Taxes\Classes\Payroll;
 use Appleton\Taxes\Countries\US\Colorado\ColoradoIncome\ColoradoIncome as BaseColoradoIncome;
@@ -10,26 +10,26 @@ class ColoradoIncome extends BaseColoradoIncome
 {
     private const SINGLE_BRACKETS = [
         [0, 0, 0],
-        [2300, 0.0463, 0],
+        [3800, 0.0463, 0],
     ];
 
     private const MARRIED_BRACKETS = [
         [0, 0, 0],
-        [8650, 0.0463, 0],
+        [11800, 0.0463, 0],
     ];
 
     private const EXEMPTION_AMOUNTS = [
         0 => 0,
-        1 => 4050,
-        2 => 8100,
-        3 => 12150,
-        4 => 16200,
-        5 => 20250,
-        6 => 24300,
-        7 => 22950,
-        8 => 21600,
-        9 => 20250,
-        10 => 18900,
+        1 => 4200,
+        2 => 8400,
+        3 => 12600,
+        4 => 16800,
+        5 => 21000,
+        6 => 25200,
+        7 => 25200,
+        8 => 25200,
+        9 => 25200,
+        10 => 25200,
     ];
 
     public function __construct(ColoradoIncomeTaxInformation $tax_information, Payroll $payroll)

--- a/src/Countries/US/Colorado/ColoradoUnemployment/V20190101/ColoradoUnemployment.php
+++ b/src/Countries/US/Colorado/ColoradoUnemployment/V20190101/ColoradoUnemployment.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\Colorado\ColoradoUnemployment\V20190101;
+
+use Appleton\Taxes\Classes\Payroll;
+use Appleton\Taxes\Countries\US\Colorado\ColoradoUnemployment\ColoradoUnemployment as BaseColoradoUnemployment;
+
+class ColoradoUnemployment extends BaseColoradoUnemployment
+{
+    const FUTA_CREDIT = 0.054;
+
+    const NEW_EMPLOYER_RATE = 0.017;
+
+    const WAGE_BASE = 13100;
+
+    public function __construct(Payroll $payroll)
+    {
+        parent::__construct($payroll);
+        $this->tax_rate = config('taxes.rates.us.colorado.unemployment', static::NEW_EMPLOYER_RATE);
+    }
+}

--- a/tests/Unit/Countries/US/Colorado/V20180101/ColoradoIncomeTest.php
+++ b/tests/Unit/Countries/US/Colorado/V20180101/ColoradoIncomeTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\Colorado\ColoradoIncome\V20180101;
+
+use Appleton\Taxes\Countries\US\Colorado\ColoradoIncome\ColoradoIncome;
+use Appleton\Taxes\Models\Countries\US\Colorado\ColoradoIncomeTaxInformation;
+use Carbon\Carbon;
+
+class ColoradoIncomeTest extends \TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Carbon::setTestNow(
+            Carbon::parse('January 1, 2018 8am', 'America/Chicago')->setTimezone('UTC')
+        );
+    }
+
+    public function testColoradoIncome()
+    {
+        $results = $this->taxes->calculate(function ($taxes) {
+            $taxes->setHomeLocation($this->getLocation('us.colorado'));
+            $taxes->setWorkLocation($this->getLocation('us.colorado'));
+            $taxes->setUser($this->user);
+            $taxes->setEarnings(1000);
+            $taxes->setPayPeriods(52);
+        });
+
+        $this->assertSame(44.00, $results->getTax(ColoradoIncome::class));
+
+        ColoradoIncomeTaxInformation::forUser($this->user)->update(['filing_status' => ColoradoIncome::FILING_MARRIED]);
+
+        $results = $this->taxes->calculate(function ($taxes) {
+            $taxes->setHomeLocation($this->getLocation('us.colorado'));
+            $taxes->setWorkLocation($this->getLocation('us.colorado'));
+            $taxes->setUser($this->user);
+            $taxes->setEarnings(1000);
+            $taxes->setPayPeriods(52);
+        });
+
+        $this->assertSame(39.00, $results->getTax(ColoradoIncome::class));
+    }
+
+    public function testIncomeExemptions()
+    {
+        ColoradoIncomeTaxInformation::forUser($this->user)->update(['exemptions' => 1]);
+
+        $results = $this->taxes->calculate(function ($taxes) {
+            $taxes->setHomeLocation($this->getLocation('us.colorado'));
+            $taxes->setWorkLocation($this->getLocation('us.colorado'));
+            $taxes->setUser($this->user);
+            $taxes->setEarnings(1000);
+            $taxes->setPayPeriods(52);
+        });
+
+        $this->assertSame(41.00, $results->getTax(ColoradoIncome::class));
+    }
+}

--- a/tests/Unit/Countries/US/Colorado/V20180101/ColoradoUnemploymentTest.php
+++ b/tests/Unit/Countries/US/Colorado/V20180101/ColoradoUnemploymentTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Appleton\Taxes\Countries\US\Colorado\ColoradoUnemployment;
+namespace Appleton\Taxes\Countries\US\Colorado\ColoradoUnemployment\V20180101;
 
-use Appleton\Taxes\Countries\US\Colorado\ColoradoIncome;
+use Appleton\Taxes\Countries\US\Colorado\ColoradoUnemployment\ColoradoUnemployment;
 use Carbon\Carbon;
 
 class ColoradoUnemploymentTest extends \TestCase

--- a/tests/Unit/Countries/US/Colorado/V20190101/ColoradoIncomeTest.php
+++ b/tests/Unit/Countries/US/Colorado/V20190101/ColoradoIncomeTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Appleton\Taxes\Countries\US\Colorado\ColoradoIncome;
+namespace Appleton\Taxes\Countries\US\Colorado\ColoradoIncome\V20190101;
 
+use Appleton\Taxes\Countries\US\Colorado\ColoradoIncome\ColoradoIncome;
 use Appleton\Taxes\Models\Countries\US\Colorado\ColoradoIncomeTaxInformation;
 use Carbon\Carbon;
 
@@ -12,7 +13,7 @@ class ColoradoIncomeTest extends \TestCase
         parent::setUp();
 
         Carbon::setTestNow(
-            Carbon::parse('January 1, 2018 8am', 'America/Chicago')->setTimezone('UTC')
+            Carbon::parse('January 1, 2019 8am', 'America/Chicago')->setTimezone('UTC')
         );
     }
 
@@ -26,7 +27,7 @@ class ColoradoIncomeTest extends \TestCase
             $taxes->setPayPeriods(52);
         });
 
-        $this->assertSame(44.00, $results->getTax(ColoradoIncome::class));
+        $this->assertSame(43.00, $results->getTax(ColoradoIncome::class));
 
         ColoradoIncomeTaxInformation::forUser($this->user)->update(['filing_status' => ColoradoIncome::FILING_MARRIED]);
 
@@ -38,7 +39,7 @@ class ColoradoIncomeTest extends \TestCase
             $taxes->setPayPeriods(52);
         });
 
-        $this->assertSame(39.00, $results->getTax(ColoradoIncome::class));
+        $this->assertSame(36.00, $results->getTax(ColoradoIncome::class));
     }
 
     public function testIncomeExemptions()
@@ -53,6 +54,6 @@ class ColoradoIncomeTest extends \TestCase
             $taxes->setPayPeriods(52);
         });
 
-        $this->assertSame(41.00, $results->getTax(ColoradoIncome::class));
+        $this->assertSame(39.00, $results->getTax(ColoradoIncome::class));
     }
 }

--- a/tests/Unit/Countries/US/Colorado/V20190101/ColoradoUnemploymentTest.php
+++ b/tests/Unit/Countries/US/Colorado/V20190101/ColoradoUnemploymentTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\Colorado\ColoradoUnemployment\V20190101;
+
+use Appleton\Taxes\Countries\US\Colorado\ColoradoUnemployment\ColoradoUnemployment;
+use Carbon\Carbon;
+
+class ColoradoUnemploymentTest extends \TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Carbon::setTestNow(
+            Carbon::parse('January 1, 2019 8am', 'America/Chicago')->setTimezone('UTC')
+        );
+    }
+
+    public function testColoradoUnemployment()
+    {
+        $results = $this->taxes->calculate(function ($taxes) {
+            $taxes->setHomeLocation($this->getLocation('us.colorado'));
+            $taxes->setWorkLocation($this->getLocation('us.colorado'));
+            $taxes->setUser($this->user);
+            $taxes->setEarnings(2300);
+        });
+
+        $this->assertSame(39.10, $results->getTax(ColoradoUnemployment::class));
+    }
+
+    public function testColoradoUnemploymentWithTaxRate()
+    {
+        config(['taxes.rates.us.colorado.unemployment' => 0.024]);
+
+        $results = $this->taxes->calculate(function ($taxes) {
+            $taxes->setHomeLocation($this->getLocation('us.colorado'));
+            $taxes->setWorkLocation($this->getLocation('us.colorado'));
+            $taxes->setUser($this->user);
+            $taxes->setEarnings(2300);
+        });
+
+        $this->assertSame(55.20, $results->getTax(ColoradoUnemployment::class));
+    }
+
+    public function testColoradoUnemploymentMetWageBase()
+    {
+        $results = $this->taxes->calculate(function ($taxes) {
+            $taxes->setHomeLocation($this->getLocation('us.colorado'));
+            $taxes->setWorkLocation($this->getLocation('us.colorado'));
+            $taxes->setUser($this->user);
+            $taxes->setEarnings(100);
+            $taxes->setYtdEarnings(13000);
+        });
+
+        $this->assertSame(1.70, $results->getTax(ColoradoUnemployment::class));
+
+        $results = $this->taxes->calculate(function ($taxes) {
+            $taxes->setHomeLocation($this->getLocation('us.colorado'));
+            $taxes->setWorkLocation($this->getLocation('us.colorado'));
+            $taxes->setUser($this->user);
+            $taxes->setEarnings(100);
+            $taxes->setYtdEarnings(13099);
+        });
+
+        $this->assertSame(.02, $results->getTax(ColoradoUnemployment::class));
+
+        $results = $this->taxes->calculate(function ($taxes) {
+            $taxes->setHomeLocation($this->getLocation('us.colorado'));
+            $taxes->setWorkLocation($this->getLocation('us.colorado'));
+            $taxes->setUser($this->user);
+            $taxes->setEarnings(100);
+            $taxes->setYtdEarnings(13100);
+        });
+
+        $this->assertSame(0.0, $results->getTax(ColoradoUnemployment::class));
+
+        $results = $this->taxes->calculate(function ($taxes) {
+            $taxes->setHomeLocation($this->getLocation('us.colorado'));
+            $taxes->setWorkLocation($this->getLocation('us.colorado'));
+            $taxes->setUser($this->user);
+            $taxes->setEarnings(100);
+            $taxes->setYtdEarnings(13101);
+        });
+
+        $this->assertSame(0.0, $results->getTax(ColoradoUnemployment::class));
+    }
+}


### PR DESCRIPTION
### Ticket
[CO: Update SUTA Wage Base and SIT](https://spurjob.atlassian.net/browse/ACC-252)

### Changes
* Move logic to `ColoradoIncome` so only the tax numbers are in the 2018 and 2019 CO income tax classes
* Implement 2019 CO taxes