### PR TITLE
Feature/acc 128 new state west virginia setup

### DIFF
--- a/src/Countries/US/Colorado/ColoradoIncome/ColoradoIncome.php
+++ b/src/Countries/US/Colorado/ColoradoIncome/ColoradoIncome.php
@@ -31,7 +31,17 @@ abstract class ColoradoIncome extends BaseStateIncome
 
     public function compute(Collection $tax_areas)
     {
-        return round(parent::compute($tax_areas));
+        if ($this->isUserClaimingExemption()) {
+            return 0.00;
+        }
+
+        $tax_amount = round($this->getTaxAmountFromTaxBrackets($this->getAdjustedEarnings(), $this->getTaxBrackets())
+            / $this->payroll->pay_periods);
+        $this->tax_total = $this->payroll->withholdTax($tax_amount) +
+            $this->payroll->withholdTax($this->getSupplementalIncomeTax()) +
+            $this->payroll->withholdTax($this->getAdditionalWithholding());
+
+        return round(((int)($this->tax_total * 100)) / 100, 2);
     }
 
     public function getAdjustedEarnings()

--- a/src/Countries/US/NorthCarolina/NorthCarolinaIncome/V20190101/NorthCarolinaIncome.php
+++ b/src/Countries/US/NorthCarolina/NorthCarolinaIncome/V20190101/NorthCarolinaIncome.php
@@ -78,8 +78,17 @@ class NorthCarolinaIncome extends BaseNorthCarolinaIncome
 
     public function compute(Collection $tax_areas)
     {
-        $result = parent::compute($tax_areas);
-        return round($result, 0);
+        if ($this->isUserClaimingExemption()) {
+            return 0.00;
+        }
+
+        $tax_amount = round($this->getTaxAmountFromTaxBrackets($this->getAdjustedEarnings(), $this->getTaxBrackets())
+            / $this->payroll->pay_periods);
+        $this->tax_total = $this->payroll->withholdTax($tax_amount) +
+            $this->payroll->withholdTax($this->getSupplementalIncomeTax()) +
+            $this->payroll->withholdTax($this->getAdditionalWithholding());
+
+        return round(((int)($this->tax_total * 100)) / 100, 2);
     }
 
     private function getStandardDeduction()

--- a/src/Countries/US/WestVirginia/WestVirginiaIncome/V20190101/WestVirginiaIncome.php
+++ b/src/Countries/US/WestVirginia/WestVirginiaIncome/V20190101/WestVirginiaIncome.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\WestVirginia\WestVirginiaIncome\V20190101;
+
+use Appleton\Taxes\Countries\US\WestVirginia\WestVirginiaIncome\WestVirginiaIncome as BaseWestVirginiaIncome;
+
+class WestVirginiaIncome extends BaseWestVirginiaIncome
+{
+    private const EXEMPTION_ALLOWANCE = 2000;
+
+    private const ONE_EARNER_BRACKETS = [
+        [0, .03, 0],
+        [10000, .04, 300],
+        [25000, .045, 900],
+        [40000, .06, 1575],
+        [60000, .065, 2775],
+    ];
+
+    private const TWO_EARNER_BRACKETS = [
+        [0, .03, 0],
+        [6000, .04, 180],
+        [15000, .045, 540],
+        [24000, .06, 945],
+        [36000, .065, 1665],
+    ];
+
+    private const SUPPLEMENTAL_BRACKETS = [
+        [0, .03],
+        [10000, .04],
+        [25000, .045],
+        [40000, .06],
+        [60000, .065],
+    ];
+
+    protected function getOneEarnerBrackets(): array
+    {
+        return self::ONE_EARNER_BRACKETS;
+    }
+
+    protected function getTwoEarnerBrackets(): array
+    {
+        return self::TWO_EARNER_BRACKETS;
+    }
+
+    protected function getExemptionsAllowance(): int
+    {
+        return self::EXEMPTION_ALLOWANCE;
+    }
+
+    protected function getSupplementalBrackets(): array
+    {
+        return self::SUPPLEMENTAL_BRACKETS;
+    }
+}

--- a/src/Countries/US/WestVirginia/WestVirginiaIncome/WestVirginiaIncome.php
+++ b/src/Countries/US/WestVirginia/WestVirginiaIncome/WestVirginiaIncome.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\WestVirginia\WestVirginiaIncome;
+
+use Appleton\Taxes\Classes\BaseStateIncome;
+use Appleton\Taxes\Classes\Payroll;
+use Appleton\Taxes\Models\Countries\US\WestVirginia\WestVirginiaIncomeTaxInformation;
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * Tax Calculation:
+ * 1. Subtract exemptions
+ * 2. Use tax tables
+ * 3. Round to the nearest dollar
+ */
+abstract class WestVirginiaIncome extends BaseStateIncome
+{
+    public function __construct(WestVirginiaIncomeTaxInformation $tax_information,
+                                Payroll $payroll)
+    {
+        parent::__construct($payroll);
+        $this->tax_information = $tax_information;
+    }
+
+    public function getSupplementalIncomeTax()
+    {
+        return $this->getSupplementalAmount($this->payroll->getSupplementalEarnings(),
+            $this->getSupplementalBrackets());
+    }
+
+    public function getTaxBrackets()
+    {
+        return ($this->tax_information->two_earner_percent)
+            ? $this->getTwoEarnerBrackets() : $this->getOneEarnerBrackets();
+    }
+
+    public function getAdjustedEarnings()
+    {
+        return $this->payroll->getEarnings() * $this->payroll->pay_periods - $this->getExemptionCredit();
+    }
+
+    public function compute(Collection $tax_areas)
+    {
+        if ($this->isUserClaimingExemption()) {
+            return 0.00;
+        }
+
+        $tax_amount = round($this->getTaxAmountFromTaxBrackets($this->getAdjustedEarnings(), $this->getTaxBrackets())
+            / $this->payroll->pay_periods);
+        $this->tax_total = $this->payroll->withholdTax($tax_amount) +
+            $this->payroll->withholdTax($this->getSupplementalIncomeTax()) +
+            $this->payroll->withholdTax($this->getAdditionalWithholding());
+
+        return round(((int)($this->tax_total * 100)) / 100, 2);
+    }
+
+    abstract protected function getOneEarnerBrackets(): array;
+
+    abstract protected function getTwoEarnerBrackets(): array;
+
+    abstract protected function getExemptionsAllowance(): int;
+
+    abstract protected function getSupplementalBrackets(): array;
+
+    private function getSupplementalAmount($amount, $table)
+    {
+        $bracket = $this->getTaxBracket($amount, $table);
+        $tax_amount = isset($bracket) ? $amount * $bracket[1] : 0;
+
+        return $tax_amount > 0 ? $tax_amount : 0;
+    }
+
+    private function getExemptionCredit(): int
+    {
+        return $this->tax_information->allowances * $this->getExemptionsAllowance();
+    }
+}

--- a/src/Countries/US/WestVirginia/WestVirginiaUnemployment/V20190101/WestVirginiaUnemployment.php
+++ b/src/Countries/US/WestVirginia/WestVirginiaUnemployment/V20190101/WestVirginiaUnemployment.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\WestVirginia\WestVirginiaUnemployment\V20190101;
+
+use Appleton\Taxes\Classes\Payroll;
+use Appleton\Taxes\Countries\US\WestVirginia\WestVirginiaUnemployment\WestVirginiaUnemployment as BaseWestVirginiaUnemployment;
+
+class WestVirginiaUnemployment extends BaseWestVirginiaUnemployment
+{
+    public const FUTA_CREDIT = 0.054;
+    public const WAGE_BASE = 12000;
+    public const TAX_RATE = 0.027;
+
+    public function __construct(Payroll $payroll)
+    {
+        parent::__construct($payroll);
+        $this->tax_rate = config('taxes.rates.us.west_virginia.unemployment', static::TAX_RATE);
+    }
+}

--- a/src/Countries/US/WestVirginia/WestVirginiaUnemployment/WestVirginiaUnemployment.php
+++ b/src/Countries/US/WestVirginia/WestVirginiaUnemployment/WestVirginiaUnemployment.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\WestVirginia\WestVirginiaUnemployment;
+
+use Appleton\Taxes\Classes\BaseStateUnemployment;
+
+abstract class WestVirginiaUnemployment extends BaseStateUnemployment
+{
+    public const TYPE = 'state';
+    public const WITHHELD = false;
+}

--- a/src/Models/Countries/US/WestVirginia/WestVirginiaIncomeTaxInformation.php
+++ b/src/Models/Countries/US/WestVirginia/WestVirginiaIncomeTaxInformation.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Appleton\Taxes\Models\Countries\US\WestVirginia;
+
+use Appleton\Taxes\Classes\BaseTaxInformationModel;
+use Appleton\Taxes\Countries\US\WestVirginia\WestVirginiaIncome\WestVirginiaIncome;
+
+class WestVirginiaIncomeTaxInformation extends BaseTaxInformationModel
+{
+    protected $config_name = 'taxes.tables.us.west_virginia.west_virginia_income_tax_information';
+
+    public static function getDefault(): WestVirginiaIncomeTaxInformation
+    {
+        $tax_information = new self();
+        $tax_information->two_earner_percent = false;
+        $tax_information->allowances = 0;
+        $tax_information->additional_withholding = 0;
+        $tax_information->exempt = false;
+        return $tax_information;
+    }
+
+    public function getAdditionalWithholding(int $value): int
+    {
+        return $value * 100;
+    }
+
+    public function setAdditionalWithholding(int $value): void
+    {
+        $this->attributes['additional_withholding'] = round($value / 100);
+    }
+
+    public static function getTax(): string
+    {
+        return WestVirginiaIncome::class;
+    }
+}

--- a/src/Providers/TaxInformationServiceProvider.php
+++ b/src/Providers/TaxInformationServiceProvider.php
@@ -30,6 +30,7 @@ class TaxInformationServiceProvider extends ServiceProvider
         \Appleton\Taxes\Models\Countries\US\NorthCarolina\NorthCarolinaIncomeTaxInformation::class,
         \Appleton\Taxes\Models\Countries\US\Virginia\VirginiaIncomeTaxInformation::class,
         \Appleton\Taxes\Models\Countries\US\WashingtonDC\WashingtonDCIncomeTaxInformation::class,
+        \Appleton\Taxes\Models\Countries\US\WestVirginia\WestVirginiaIncomeTaxInformation::class,
         \Appleton\Taxes\Models\Countries\US\Wisconsin\WisconsinIncomeTaxInformation::class,
     ];
 

--- a/src/Providers/TaxServiceProvider.php
+++ b/src/Providers/TaxServiceProvider.php
@@ -223,6 +223,8 @@ class TaxServiceProvider extends ServiceProvider
         \Appleton\Taxes\Countries\US\Virginia\VirginiaUnemployment\VirginiaUnemployment::class,
         \Appleton\Taxes\Countries\US\WashingtonDC\WashingtonDCIncome\WashingtonDCIncome::class,
         \Appleton\Taxes\Countries\US\WashingtonDC\WashingtonDCUnemployment\WashingtonDCUnemployment::class,
+        \Appleton\Taxes\Countries\US\WestVirginia\WestVirginiaIncome\WestVirginiaIncome::class,
+        \Appleton\Taxes\Countries\US\WestVirginia\WestVirginiaUnemployment\WestVirginiaUnemployment::class,
         \Appleton\Taxes\Countries\US\Wisconsin\WisconsinIncome\WisconsinIncome::class,
         \Appleton\Taxes\Countries\US\Wisconsin\WisconsinUnemployment\WisconsinUnemployment::class,
     ];

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -79,6 +79,10 @@ return [
                 'washingtondc_income_tax_information' => env('TAXES_WASHINGTONDC_INCOME_TAX_INFORMATION', 'washingtondc_income_tax_information'),
             ],
 
+            'west_virginia' => [
+                'west_virginia_income_tax_information' => env('TAXES_WEST_VIRGINIA_INCOME_TAX_INFORMATION', 'west_virginia_income_tax_information'),
+            ],
+
             'wisconsin' => [
                 'wisconsin_income_tax_information' => env('TAXES_WISCONSIN_INCOME_TAX_INFORMATION', 'wisconsin_income_tax_information'),
             ],
@@ -138,6 +142,10 @@ return [
 
             'washingtondc' => [
                 'unemployment' => env('TAXES_WASHINGTONDC_UNEMPLOYMENT_TAX_RATE', 0.027),
+            ],
+
+            'west_virginia' => [
+                'unemployment' => env('TAXES_WEST_VIRGINIA_UNEMPLOYMENT_TAX_RATE', 0.027),
             ],
 
             'wisconsin' => [

--- a/src/migrations/2019_06_27_000000_add_west_virginia_income_tax_information_table.php
+++ b/src/migrations/2019_06_27_000000_add_west_virginia_income_tax_information_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Appleton\Taxes\Countries\US\WestVirginia\WestVirginiaIncome\WestVirginiaIncome;
+use Appleton\Taxes\Countries\US\WestVirginia\WestVirginiaUnemployment\WestVirginiaUnemployment;
+use Appleton\Taxes\Models\TaxArea;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class AddWestVirginiaIncomeTaxInformationTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('west_virginia_income_tax_information', static function (Blueprint $table) {
+            $table->increments('id');
+            $table->boolean('two_earner_percent')->default(false);
+            $table->integer('allowances')->default(0);
+            $table->integer('additional_withholding')->default(0);
+            $table->boolean('exempt')->default(false);
+        });
+
+        $income_tax_id = DB::table('taxes')->insertGetId([
+            'name' => 'West Virginia Income Tax',
+            'class' => WestVirginiaIncome::class,
+        ]);
+
+        $unemployment_tax_id = DB::table('taxes')->insertGetId([
+            'name' => 'West Virginia Unemployment Tax',
+            'class' => WestVirginiaUnemployment::class,
+        ]);
+
+        $id = DB::table('governmental_unit_areas')->where('name', 'West Virginia')->first()->id;
+        DB::table('tax_areas')->insert([
+            'tax_id' => $income_tax_id,
+            'work_governmental_unit_area_id' => $id,
+            'based' => TaxArea::BASED_ON_WORK_LOCATION,
+        ]);
+
+        DB::table('tax_areas')->insert([
+            'tax_id' => $unemployment_tax_id,
+            'home_governmental_unit_area_id' => $id,
+            'based' => TaxArea::BASED_ON_HOME_LOCATION,
+        ]);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -37,6 +37,7 @@ use Appleton\Taxes\Models\Countries\US\NorthCarolina\NorthCarolinaIncomeTaxInfor
 use Appleton\Taxes\Models\Countries\US\Oklahoma\OklahomaIncomeTaxInformation;
 use Appleton\Taxes\Models\Countries\US\Virginia\VirginiaIncomeTaxInformation;
 use Appleton\Taxes\Models\Countries\US\WashingtonDC\WashingtonDCIncomeTaxInformation;
+use Appleton\Taxes\Models\Countries\US\WestVirginia\WestVirginiaIncomeTaxInformation;
 use Appleton\Taxes\Models\Countries\US\Wisconsin\WisconsinIncomeTaxInformation;
 use Appleton\Taxes\Providers\TaxesServiceProvider;
 use Carbon\Carbon;
@@ -215,6 +216,13 @@ class TestCase extends BaseTestCase
             'dependents' => 0,
             'exempt' => false,
             'filing_status' => WashingtonDCIncome::FILING_SINGLE,
+        ], $this->user);
+
+        WestVirginiaIncomeTaxInformation::createForUser([
+            'two_earner_percent' => false,
+            'allowances' => 0,
+            'additional_withholding' => 0,
+            'exempt' => false,
         ], $this->user);
 
         WisconsinIncomeTaxInformation::createForUser([
@@ -405,6 +413,7 @@ class TestCase extends BaseTestCase
             'us.texas' => [31.9686, -99.9018],
             'us.virginia' => [37.5407, -77.4360],
             'us.washingtondc' => [38.9072, -77.0369],
+            'us.west_virginia' => [38.3498, -81.6326],
             'us.wisconsin' => [43.0849721, -89.4764603],
         ];
 

--- a/tests/Unit/Countries/US/WestVirginia/WestVirginiaIncomeTest.php
+++ b/tests/Unit/Countries/US/WestVirginia/WestVirginiaIncomeTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Appleton\Taxes\Unit\Countries\US\WestVirginia;
+
+use Appleton\Taxes\Classes\TaxResults;
+use Appleton\Taxes\Countries\US\WestVirginia\WestVirginiaIncome\WestVirginiaIncome;
+use Appleton\Taxes\Models\Countries\US\WestVirginia\WestVirginiaIncomeTaxInformation;
+use Carbon\Carbon;
+use TestCase;
+
+class WestVirginiaIncomeTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        Carbon::setTestNow(Carbon::parse('2019-01-01'));
+    }
+
+    /**
+     * Single income, 3 allowances, 300 wages
+     *
+     * 300 * 52 = 15600 annual wages
+     * 15600 - (3 * 2000) allowance credit = 9600 taxable income
+     * 0 + (9600 * .03) tax withholding = 288 annual tax
+     * 780 / 52 = 5.538 weekly tax
+     */
+    public function testCaliforniaIncomeTest1(): void
+    {
+        $results = $this->calculateTaxes(false, 3, 300);
+        self::assertThat($results->getTax(WestVirginiaIncome::class), self::identicalTo(6.0));
+    }
+
+    /**
+     * Single income, 2 allowances, 500 wages
+     *
+     * 500 * 52 = 26000 annual wages
+     * 26000 - (2 * 2000) allowance credit = 22000 taxable income
+     * 300 + ((22000 - 10000) * .04) tax withholding = 780 annual tax
+     * 780 / 52 = 15 weekly tax
+     */
+    public function testCaliforniaIncomeTest2(): void
+    {
+        $results = $this->calculateTaxes(false, 2, 500.0);
+        self::assertThat($results->getTax(WestVirginiaIncome::class), self::identicalTo(15.0));
+    }
+
+    /**
+     * Single income, 4 allowances, 700 wages
+     *
+     * 700 * 52 = 36400 annual wages
+     * 36400 - (4 * 2000) allowance credit = 28400 taxable income
+     * 900 + ((28400 - 25000) * .045) tax withholding = 1053 annual tax
+     * 1053 / 52 = 20.25 weekly tax
+     */
+    public function testCaliforniaIncomeTest3(): void
+    {
+        $results = $this->calculateTaxes(false, 4, 700.0);
+        self::assertThat($results->getTax(WestVirginiaIncome::class), self::identicalTo(20.0));
+    }
+
+    /**
+     * Single income, 1 allowance, 1000 wages
+     *
+     * 1000 * 52 = 52000 annual wages
+     * 52000 - (1 * 2000) allowance credit = 50000 taxable income
+     * 1575 + ((50000 - 40000) * .06) tax withholding = 2175 annual tax
+     * 2175 / 52 = 41.826 weekly tax
+     */
+    public function testCaliforniaIncomeTest4(): void
+    {
+        $results = $this->calculateTaxes(false, 1, 1000.0);
+        self::assertThat($results->getTax(WestVirginiaIncome::class), self::identicalTo(42.0));
+    }
+
+    /**
+     * Single income, 2 allowances, 2000 wages
+     *
+     * 2000 * 52 = 104000 annual wages
+     * 104000 - (2 * 2000) allowance credit = 100000 taxable income
+     * 2775 + ((100000 - 60000) * .065) tax withholding = 5375 annual tax
+     * 5375 / 52 = 103.365 weekly tax
+     */
+    public function testCaliforniaIncomeTest5(): void
+    {
+        $results = $this->calculateTaxes(false, 2, 2000.0);
+        self::assertThat($results->getTax(WestVirginiaIncome::class), self::identicalTo(103.0));
+    }
+
+    /**
+     * Two income, 4 allowances, 300 wages
+     *
+     * 300 * 52 = 15600 annual wages
+     * 15600 - (4 * 2000) allowance credit = 7600 taxable income
+     * 180 + ((7600 - 6000) * .04) tax withholding = 244 annual tax
+     * 244 / 52 = 4.692 weekly tax
+     */
+    public function testCaliforniaIncomeTest6(): void
+    {
+        $results = $this->calculateTaxes(true, 4, 300.0);
+        self::assertThat($results->getTax(WestVirginiaIncome::class), self::identicalTo(5.0));
+    }
+
+    /**
+     * Two income, 1 allowance, 500 wages
+     *
+     * 500 * 52 = 26000 annual wages
+     * 26000 - (1 * 2000) allowance credit = 24000 taxable income
+     * 945 + ((24000 - 24000) * .06) tax withholding = 945 annual tax
+     * 945 / 52 = 18.173 weekly tax
+     */
+    public function testCaliforniaIncomeTest7(): void
+    {
+        $results = $this->calculateTaxes(true, 1, 500.0);
+        self::assertThat($results->getTax(WestVirginiaIncome::class), self::identicalTo(18.0));
+    }
+
+    /**
+     * Two income, 2 allowances, 700 wages
+     *
+     * 700 * 52 = 36400 annual wages
+     * 36400 - (2 * 2000) allowance credit = 32400 taxable income
+     * 945 + ((32400 - 24000) * .06) tax withholding = 1449 annual tax
+     * 1449 / 52 = 27.865 weekly tax
+     */
+    public function testCaliforniaIncomeTest8(): void
+    {
+        $results = $this->calculateTaxes(true, 2, 700.0);
+        self::assertThat($results->getTax(WestVirginiaIncome::class), self::identicalTo(28.0));
+    }
+
+    /**
+     * Two income, 4 allowances, 1000 wages
+     *
+     * 1000 * 52 = 52000 annual wages
+     * 52000 - (4 * 2000) allowance credit = 44000 taxable income
+     * 1665 + ((44000 - 36000) * .065) tax withholding = 2185 annual tax
+     * 2185 / 52 = 42.019 weekly tax
+     */
+    public function testCaliforniaIncomeTest9(): void
+    {
+        $results = $this->calculateTaxes(true, 4, 1000.0);
+        self::assertThat($results->getTax(WestVirginiaIncome::class), self::identicalTo(42.0));
+    }
+
+    /**
+     * Two income, 3 allowances, 2000 wages
+     *
+     * 2000 * 52 = 104000 annual wages
+     * 104000 - (3 * 2000) allowance credit = 98000 taxable income
+     * 1665 + ((98000 - 36000) * .065) tax withholding = 5695 annual tax
+     * 5695 / 52 = 109.519 weekly tax
+     */
+    public function testCaliforniaIncomeTest10(): void
+    {
+        $results = $this->calculateTaxes(true, 3, 2000.0);
+        self::assertThat($results->getTax(WestVirginiaIncome::class), self::identicalTo(110.0));
+    }
+
+    private function calculateTaxes(bool $two_earner_percent, int $allowances,
+                                    int $earnings): TaxResults
+    {
+        WestVirginiaIncomeTaxInformation::forUser($this->user)->update([
+            'two_earner_percent' => $two_earner_percent,
+            'allowances' => $allowances,
+        ]);
+
+        return $this->taxes->calculate(function ($taxes) use ($earnings) {
+            $taxes->setHomeLocation($this->getLocation('us.west_virginia'));
+            $taxes->setWorkLocation($this->getLocation('us.west_virginia'));
+            $taxes->setUser($this->user);
+            $taxes->setEarnings($earnings);
+            $taxes->setPayPeriods(52);
+        });
+    }
+}

--- a/tests/Unit/Countries/US/WestVirginia/WestVirginiaUnemploymentTest.php
+++ b/tests/Unit/Countries/US/WestVirginia/WestVirginiaUnemploymentTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Appleton\Taxes\Unit\Countries\US\WestVirginia;
+
+use Appleton\Taxes\Classes\TaxResults;
+use Appleton\Taxes\Countries\US\WestVirginia\WestVirginiaIncome\WestVirginiaIncome;
+use Appleton\Taxes\Countries\US\WestVirginia\WestVirginiaUnemployment\WestVirginiaUnemployment;
+use Carbon\Carbon;
+use TestCase;
+
+class WestVirginiaUnemploymentTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        Carbon::setTestNow(Carbon::parse('2019-01-01'));
+    }
+
+    public function testWestVirginiaUnemploymentWithTaxRate(): void
+    {
+        config(['taxes.rates.us.west_virginia.unemployment' => 0.02]);
+
+        $results = $this->calculateTaxes(100);
+        $this->assertSame(2.0, $results->getTax(WestVirginiaUnemployment::class));
+    }
+
+    public function testWestVirginiaUnemploymentMetWageBase(): void
+    {
+        // not met 7000 wage base, all 100$ taxable at 2.7%
+        $results = $this->calculateTaxes(100, 11900);
+        $this->assertSame(2.7, $results->getTax(WestVirginiaUnemployment::class));
+
+        // will meet 7000 wage base, only 1$ taxable at 2.7%
+        $results = $this->calculateTaxes(100, 11999);
+        $this->assertSame(.03, $results->getTax(WestVirginiaUnemployment::class));
+
+        // already met 7000 wage base, none taxable
+        $results = $this->calculateTaxes(100, 12000);
+        $this->assertSame(0.0, $results->getTax(WestVirginiaUnemployment::class));
+
+        // already met 7000 wage base, none taxable
+        $results = $this->calculateTaxes(100, 12001);
+        $this->assertSame(0.0, $results->getTax(WestVirginiaUnemployment::class));
+
+        // already met 7000 wage base, none taxable
+        $results = $this->calculateTaxes(100, 12100);
+        $this->assertSame(0.0, $results->getTax(WestVirginiaUnemployment::class));
+    }
+
+    public function testWestVirginiaUnemploymentWorkOutOfState(): void
+    {
+        $results = $this->calculateTaxes(100, 0, 'us.alabama');
+
+        $this->assertNull($results->getTax(WestVirginiaIncome::class));
+        $this->assertSame(2.7, $results->getTax(WestVirginiaUnemployment::class));
+    }
+
+    private function calculateTaxes(int $earnings, int $ytd_earnings = 0,
+                                    string $work_location = 'us.west_virginia'): TaxResults
+    {
+        return $this->taxes->calculate(function ($taxes) use ($earnings, $ytd_earnings, $work_location) {
+            $taxes->setHomeLocation($this->getLocation('us.west_virginia'));
+            $taxes->setWorkLocation($this->getLocation($work_location));
+            $taxes->setUser($this->user);
+            $taxes->setEarnings($earnings);
+            $taxes->setYtdEarnings($ytd_earnings);
+        });
+    }
+}


### PR DESCRIPTION
### Tickets
* [New State: West Virginia Setup/SIT/SUTA](https://spurjob.atlassian.net/browse/ACC-128)
* [Incorrectly calling parent compute when needing to round tax results
](https://spurjob.atlassian.net/browse/ACC-261)

### Changes
* Implement West Virginia tax/unemployment
* Update CO and NC state incomes to overwrite `compute` instead of calling `parent::compute` for rounding purposes