### PR TITLE
ACC-223 Calculate additional deductions better

### DIFF
--- a/src/Countries/US/NewJersey/NewJerseyDisabilityInsurance/V20190101/NewJerseyDisabilityInsurance.php
+++ b/src/Countries/US/NewJersey/NewJerseyDisabilityInsurance/V20190101/NewJerseyDisabilityInsurance.php
@@ -16,7 +16,7 @@ class NewJerseyDisabilityInsurance extends BaseNewJerseyDisabilityInsurance
     public function getBaseEarnings()
     {
         if (($this->payroll->earnings + $this->payroll->wtd_earnings) < self::WAGE_BASE) {
-            return $this->payroll->wtd_earnings;
+            return $this->payroll->wtd_earnings > 0 ? $this->payroll->wtd_earnings : $this->payroll->earnings;
         } elseif (($this->payroll->earnings + $this->payroll->wtd_earnings) >= self::WAGE_BASE) {
             $total = self::WAGE_BASE - $this->payroll->earnings;
 

--- a/src/Countries/US/NewJersey/NewJerseyDisabilityInsurance/V20190101/NewJerseyDisabilityInsurance.php
+++ b/src/Countries/US/NewJersey/NewJerseyDisabilityInsurance/V20190101/NewJerseyDisabilityInsurance.php
@@ -15,10 +15,10 @@ class NewJerseyDisabilityInsurance extends BaseNewJerseyDisabilityInsurance
 
     public function getBaseEarnings()
     {
-        if (($this->payroll->earnings + $this->payroll->wtd_earnings) < self::WAGE_BASE) {
-            return $this->payroll->wtd_earnings > 0 ? $this->payroll->wtd_earnings : $this->payroll->earnings;
-        } elseif (($this->payroll->earnings + $this->payroll->wtd_earnings) >= self::WAGE_BASE) {
-            $total = self::WAGE_BASE - $this->payroll->earnings;
+        if (($this->payroll->earnings + $this->payroll->ytd_earnings + $this->payroll->wtd_earnings) < self::WAGE_BASE) {
+            return max(min(static::WAGE_BASE - $this->payroll->ytd_earnings, $this->payroll->getEarnings()), 0);
+        } elseif (($this->payroll->earnings + $this->payroll->ytd_earnings + $this->payroll->wtd_earnings) >= self::WAGE_BASE) {
+            $total = self::WAGE_BASE - $this->payroll->ytd_earnings;
 
             return $total > 0 ? $total : 0;
         }

--- a/src/Countries/US/NewJersey/NewJerseyFamilyMedicalLeave/V20190101/NewJerseyFamilyMedicalLeave.php
+++ b/src/Countries/US/NewJersey/NewJerseyFamilyMedicalLeave/V20190101/NewJerseyFamilyMedicalLeave.php
@@ -15,10 +15,10 @@ class NewJerseyFamilyMedicalLeave extends BaseNewJerseyFamilyMedicalLeave
 
     public function getBaseEarnings()
     {
-        if (($this->payroll->earnings + $this->payroll->wtd_earnings) < self::WAGE_BASE) {
-            return $this->payroll->wtd_earnings > 0 ? $this->payroll->wtd_earnings : $this->payroll->earnings;
-        } elseif (($this->payroll->earnings + $this->payroll->wtd_earnings) >= self::WAGE_BASE) {
-            $total = self::WAGE_BASE - $this->payroll->earnings;
+        if (($this->payroll->earnings + $this->payroll->ytd_earnings + $this->payroll->wtd_earnings) < self::WAGE_BASE) {
+            return max(min(static::WAGE_BASE - $this->payroll->ytd_earnings, $this->payroll->getEarnings()), 0);
+        } elseif (($this->payroll->earnings + $this->payroll->ytd_earnings + $this->payroll->wtd_earnings) >= self::WAGE_BASE) {
+            $total = self::WAGE_BASE - $this->payroll->ytd_earnings;
 
             return $total > 0 ? $total : 0;
         }

--- a/src/Countries/US/NewJersey/NewJerseyFamilyMedicalLeave/V20190101/NewJerseyFamilyMedicalLeave.php
+++ b/src/Countries/US/NewJersey/NewJerseyFamilyMedicalLeave/V20190101/NewJerseyFamilyMedicalLeave.php
@@ -16,7 +16,7 @@ class NewJerseyFamilyMedicalLeave extends BaseNewJerseyFamilyMedicalLeave
     public function getBaseEarnings()
     {
         if (($this->payroll->earnings + $this->payroll->wtd_earnings) < self::WAGE_BASE) {
-            return $this->payroll->wtd_earnings;
+            return $this->payroll->wtd_earnings > 0 ? $this->payroll->wtd_earnings : $this->payroll->earnings;
         } elseif (($this->payroll->earnings + $this->payroll->wtd_earnings) >= self::WAGE_BASE) {
             $total = self::WAGE_BASE - $this->payroll->earnings;
 

--- a/src/Countries/US/NewJersey/NewJerseyUnemploymentInsurance/V20190101/NewJerseyUnemploymentInsurance.php
+++ b/src/Countries/US/NewJersey/NewJerseyUnemploymentInsurance/V20190101/NewJerseyUnemploymentInsurance.php
@@ -16,7 +16,7 @@ class NewJerseyUnemploymentInsurance extends BaseNewJerseyUnemploymentInsurance
     public function getBaseEarnings()
     {
         if (($this->payroll->earnings + $this->payroll->wtd_earnings) < self::WAGE_BASE) {
-            return $this->payroll->wtd_earnings;
+            return $this->payroll->wtd_earnings > 0 ? $this->payroll->wtd_earnings : $this->payroll->earnings;
         } elseif (($this->payroll->earnings + $this->payroll->wtd_earnings) >= self::WAGE_BASE) {
             $total = self::WAGE_BASE - $this->payroll->earnings;
 

--- a/src/Countries/US/NewJersey/NewJerseyUnemploymentInsurance/V20190101/NewJerseyUnemploymentInsurance.php
+++ b/src/Countries/US/NewJersey/NewJerseyUnemploymentInsurance/V20190101/NewJerseyUnemploymentInsurance.php
@@ -15,10 +15,10 @@ class NewJerseyUnemploymentInsurance extends BaseNewJerseyUnemploymentInsurance
 
     public function getBaseEarnings()
     {
-        if (($this->payroll->earnings + $this->payroll->wtd_earnings) < self::WAGE_BASE) {
-            return $this->payroll->wtd_earnings > 0 ? $this->payroll->wtd_earnings : $this->payroll->earnings;
-        } elseif (($this->payroll->earnings + $this->payroll->wtd_earnings) >= self::WAGE_BASE) {
-            $total = self::WAGE_BASE - $this->payroll->earnings;
+        if (($this->payroll->earnings + $this->payroll->ytd_earnings + $this->payroll->wtd_earnings) < self::WAGE_BASE) {
+            return max(min(static::WAGE_BASE - $this->payroll->ytd_earnings, $this->payroll->getEarnings()), 0);
+        } elseif (($this->payroll->earnings + $this->payroll->ytd_earnings + $this->payroll->wtd_earnings) >= self::WAGE_BASE) {
+            $total = self::WAGE_BASE - $this->payroll->ytd_earnings;
 
             return $total > 0 ? $total : 0;
         }

--- a/tests/Unit/Countries/US/NewJersey/NewJerseyDisabilityInsuranceTest.php
+++ b/tests/Unit/Countries/US/NewJersey/NewJerseyDisabilityInsuranceTest.php
@@ -10,18 +10,18 @@ class NewJerseyDisabilityInsuranceTest extends \TestCase
     /**
      * @dataProvider provideTestData
      */
-    public function testNewJerseyDisabilityInsurance($date, $wtd_earnings, $earnings, $result)
+    public function testNewJerseyDisabilityInsurance($date, $earnings, $ytd_earnings, $result)
     {
         Carbon::setTestNow(
             Carbon::parse($date, 'America/Chicago')->setTimezone('UTC')
         );
 
-        $results = $this->taxes->calculate(function ($taxes) use ($wtd_earnings, $earnings) {
+        $results = $this->taxes->calculate(function ($taxes) use ($ytd_earnings, $earnings) {
             $taxes->setHomeLocation($this->getLocation('us.new_jersey'));
             $taxes->setWorkLocation($this->getLocation('us.new_jersey'));
             $taxes->setUser($this->user);
-            $taxes->setWtdEarnings($wtd_earnings);
             $taxes->setEarnings($earnings);
+            $taxes->setYtdEarnings($ytd_earnings);
         });
 
         $this->assertSame($result, $results->getTax(NewJerseyDisabilityInsurance::class));

--- a/tests/Unit/Countries/US/NewJersey/NewJerseyFamilyMedicalLeaveTest.php
+++ b/tests/Unit/Countries/US/NewJersey/NewJerseyFamilyMedicalLeaveTest.php
@@ -10,18 +10,18 @@ class NewJerseyFamilyMedicalLeaveTest extends \TestCase
     /**
      * @dataProvider provideTestData
      */
-    public function testNewJerseyFamilyMedicalLeave($date, $wtd_earnings, $earnings, $result)
+    public function testNewJerseyFamilyMedicalLeave($date, $earnings, $ytd_earnings, $result)
     {
         Carbon::setTestNow(
             Carbon::parse($date, 'America/Chicago')->setTimezone('UTC')
         );
 
-        $results = $this->taxes->calculate(function ($taxes) use ($wtd_earnings, $earnings) {
+        $results = $this->taxes->calculate(function ($taxes) use ($ytd_earnings, $earnings) {
             $taxes->setHomeLocation($this->getLocation('us.new_jersey'));
             $taxes->setWorkLocation($this->getLocation('us.new_jersey'));
             $taxes->setUser($this->user);
-            $taxes->setWtdEarnings($wtd_earnings);
             $taxes->setEarnings($earnings);
+            $taxes->setYtdEarnings($ytd_earnings);
         });
 
         $this->assertSame($result, $results->getTax(NewJerseyFamilyMedicalLeave::class));

--- a/tests/Unit/Countries/US/NewJersey/NewJerseyUnemploymentInsuranceTest.php
+++ b/tests/Unit/Countries/US/NewJersey/NewJerseyUnemploymentInsuranceTest.php
@@ -10,18 +10,18 @@ class NewJerseyUnemploymentInsuranceTest extends \TestCase
     /**
      * @dataProvider provideTestData
      */
-    public function testNewJerseyUnemploymentInsurance($date, $wtd_earnings, $earnings, $result)
+    public function testNewJerseyUnemploymentInsurance($date, $earnings, $ytd_earnings, $result)
     {
         Carbon::setTestNow(
             Carbon::parse($date, 'America/Chicago')->setTimezone('UTC')
         );
 
-        $results = $this->taxes->calculate(function ($taxes) use ($wtd_earnings, $earnings) {
+        $results = $this->taxes->calculate(function ($taxes) use ($ytd_earnings, $earnings) {
             $taxes->setHomeLocation($this->getLocation('us.new_jersey'));
             $taxes->setWorkLocation($this->getLocation('us.new_jersey'));
             $taxes->setUser($this->user);
-            $taxes->setWtdEarnings($wtd_earnings);
             $taxes->setEarnings($earnings);
+            $taxes->setYtdEarnings($ytd_earnings);
         });
 
         $this->assertSame($result, $results->getTax(NewJerseyUnemploymentInsurance::class));


### PR DESCRIPTION
refs: https://spurjob.atlassian.net/browse/ACC-223

So the problem was that I was thinking that earnings was the ytd earnings but it isn't. This fixes the NJ additional deductions to use ytd properly.