### PR TITLE
ACC-310 - Speed up tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ install:
 before_script:
   - psql -U postgres -c 'create database taxes'
   - psql -U postgres -d taxes -c 'create extension postgis'
+  - php init_db.php
 
 script:
   - vendor/phpunit/phpunit/phpunit --stop-on-error --stop-on-failure

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,11 @@
         ]
     },
     "scripts": {
-        "test": "phpunit",
+        "init_db": "@php init_db.php",
+        "test": [
+            "@init_db",
+            "phpunit"
+        ],
         "check-style": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",
         "fix-style": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests"
     },

--- a/init_db.php
+++ b/init_db.php
@@ -1,0 +1,8 @@
+<?php
+
+use Appleton\Taxes\InitDb;
+
+require __DIR__.'/vendor/autoload.php';
+require __DIR__.'/tests/InitDb.php';
+
+InitDb::initDb();

--- a/tests/InitDb.php
+++ b/tests/InitDb.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Appleton\Taxes;
+
+use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
+use Orchestra\Database\ConsoleServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+class InitDb extends TestCase
+{
+    public static function initDb(): void
+    {
+        $init_db = new self();
+        $init_db->setUp();
+
+        $init_db->artisan('migrate:fresh');
+        $init_db->artisan('migrate', [
+            '--database' => 'testing',
+            '--path' => 'migrations',
+        ]);
+        $init_db->artisan('migrate', [
+            '--database' => 'testing',
+            '--path' => dirname(__DIR__).'/src/migrations',
+            '--realpath' => true,
+        ]);
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app->useEnvironmentPath(__DIR__.'/..');
+
+        $app->bootstrapWith([LoadEnvironmentVariables::class]);
+
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('database.default', 'testing');
+
+        $app['config']->set('database.connections.testing', [
+            'driver' => 'pgsql',
+            'host' => env('TEST_DB_HOST'),
+            'port' => env('TEST_DB_PORT', 5432),
+            'database' => env('TEST_DB_DATABASE'),
+            'username' => env('PG_USER', env('TEST_DB_USERNAME')),
+            'password' => env('PG_PASSWORD', env('TEST_DB_PASSWORD')),
+            'charset' => 'utf8',
+            'prefix' => '',
+            'schema' => 'public',
+        ]);
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            ConsoleServiceProvider::class,
+        ];
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -46,7 +46,7 @@ use Appleton\Taxes\Providers\TaxesServiceProvider;
 use Carbon\Carbon;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Orchestra\Database\ConsoleServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
@@ -55,7 +55,7 @@ use Orchestra\Testbench\TestCase as BaseTestCase;
  */
 class TestCase extends BaseTestCase
 {
-    use DatabaseMigrations;
+    use DatabaseTransactions;
 
     protected $user_model;
     protected $user;
@@ -73,13 +73,6 @@ class TestCase extends BaseTestCase
         Carbon::setTestNow(
             Carbon::parse('January 1, 2017 8am', 'America/Chicago')->setTimezone('UTC')
         );
-
-        $this->loadLaravelMigrations(['--database' => 'testing']);
-
-        $this->loadMigrationsFrom([
-            '--database' => 'testing',
-            '--realpath' => realpath(__DIR__.'/../src/migrations'),
-        ]);
 
         $this->user_model = app(config('taxes.user'));
 

--- a/tests/Unit/Countries/US/Illinois/IllinoisIncomeTest.php
+++ b/tests/Unit/Countries/US/Illinois/IllinoisIncomeTest.php
@@ -114,12 +114,12 @@ class IllinoisIncomeTest extends TestCase
                                     float $earnings, bool $exempt = false,
                                     int $additional_withholding = 0): TaxResults
     {
-        IllinoisIncomeTaxInformation::createForUser([
+        IllinoisIncomeTaxInformation::forUser($this->user)->update([
             'basic_allowances' => $basic_allowances,
             'additional_allowances' => $additional_allowances,
             'additional_withholding' => $additional_withholding,
             'exempt' => $exempt,
-        ], $this->user);
+        ]);
 
         return $this->taxes->calculate(function (Taxes $taxes) use ($earnings) {
             $taxes->setHomeLocation($this->getLocation('us.illinois'));

--- a/tests/Unit/Countries/US/Indiana/AdamsIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/AdamsIncomeTest.php
@@ -6,6 +6,7 @@ use Appleton\Taxes\Classes\Taxes;
 use Appleton\Taxes\Countries\US\Indiana\AdamsIncome\AdamsIncome;
 use Appleton\Taxes\Countries\US\Indiana\AllenIncome\AllenIncome;
 use Appleton\Taxes\Countries\US\Indiana\IndianaIncome\IndianaIncome;
+use Appleton\Taxes\Models\Countries\US\Illinois\IllinoisIncomeTaxInformation;
 use Appleton\Taxes\Models\Countries\US\Indiana\IndianaIncomeTaxInformation;
 use Carbon\Carbon;
 use TestCase;
@@ -24,14 +25,14 @@ class AdamsIncomeTest extends TestCase
      */
     public function testAdamsIncomeCountyLived(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 1,
             'county_worked' => 3,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana'));
@@ -48,14 +49,14 @@ class AdamsIncomeTest extends TestCase
 
     public function testAdamsIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 1,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana'));

--- a/tests/Unit/Countries/US/Indiana/AllenIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/AllenIncomeTest.php
@@ -32,14 +32,14 @@ class AllenIncomeTest extends TestCase
      */
     public function testAllenIncomeCountyLived(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 1,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 2,
             'county_worked' => 3,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana'));
@@ -54,14 +54,14 @@ class AllenIncomeTest extends TestCase
 
     public function testAllenIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 1,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 2,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.alabama'));

--- a/tests/Unit/Countries/US/Indiana/BartholomewIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/BartholomewIncomeTest.php
@@ -23,14 +23,14 @@ class BartholomewIncomeTest extends TestCase
      */
     public function testBartholomewIncomeCountyLived(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 3,
             'county_worked' => 2,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.adams'));
@@ -45,14 +45,14 @@ class BartholomewIncomeTest extends TestCase
 
     public function testBartholomewIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 3,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana'));

--- a/tests/Unit/Countries/US/Indiana/BentonIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/BentonIncomeTest.php
@@ -23,14 +23,14 @@ class BentonIncomeTest extends TestCase
      */
     public function testBentonIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 4,
             'county_worked' => 2,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana'));
@@ -45,14 +45,14 @@ class BentonIncomeTest extends TestCase
 
     public function testBentonIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 4,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana'));

--- a/tests/Unit/Countries/US/Indiana/BlackfordIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/BlackfordIncomeTest.php
@@ -23,14 +23,14 @@ class BlackfordIncomeTest extends TestCase
      */
     public function testBlackfordIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 5,
             'county_worked' => 2,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.blackford'));
@@ -45,14 +45,14 @@ class BlackfordIncomeTest extends TestCase
 
     public function testBlackfordIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 5,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.blackford'));

--- a/tests/Unit/Countries/US/Indiana/BooneIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/BooneIncomeTest.php
@@ -23,14 +23,14 @@ class BooneIncomeTest extends TestCase
      */
     public function testBooneIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 6,
             'county_worked' => 5,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.boone'));
@@ -45,14 +45,14 @@ class BooneIncomeTest extends TestCase
 
     public function testBooneIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 6,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.boone'));

--- a/tests/Unit/Countries/US/Indiana/BrownIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/BrownIncomeTest.php
@@ -23,14 +23,14 @@ class BrownIncomeTest extends TestCase
      */
     public function testBrownIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 7,
             'county_worked' => 6,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana'));
@@ -45,14 +45,14 @@ class BrownIncomeTest extends TestCase
 
     public function testBrownIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 7,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.adams'));

--- a/tests/Unit/Countries/US/Indiana/CarrollIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/CarrollIncomeTest.php
@@ -23,14 +23,14 @@ class CarrollIncomeTest extends TestCase
      */
     public function testCarrollIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 8,
             'county_worked' => 7,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.carroll'));
@@ -45,14 +45,14 @@ class CarrollIncomeTest extends TestCase
 
     public function testCarrollIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 8,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.carroll'));

--- a/tests/Unit/Countries/US/Indiana/CassIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/CassIncomeTest.php
@@ -23,14 +23,14 @@ class CassIncomeTest extends TestCase
      */
     public function testCassIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 9,
             'county_worked' => 8,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.cass'));
@@ -45,14 +45,14 @@ class CassIncomeTest extends TestCase
 
     public function testCassIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 9,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.cass'));

--- a/tests/Unit/Countries/US/Indiana/ClarkIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/ClarkIncomeTest.php
@@ -23,14 +23,14 @@ class ClarkIncomeTest extends TestCase
      */
     public function testClarkIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 10,
             'county_worked' => 9,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.clark'));
@@ -45,14 +45,14 @@ class ClarkIncomeTest extends TestCase
 
     public function testClarkIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 10,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.clark'));

--- a/tests/Unit/Countries/US/Indiana/ClayIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/ClayIncomeTest.php
@@ -32,14 +32,14 @@ class ClayIncomeTest extends TestCase
      */
     public function testClayIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 1,
             'dependent_exemptions' => 1,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 11,
             'county_worked' => 10,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.clark'));
@@ -54,14 +54,14 @@ class ClayIncomeTest extends TestCase
 
     public function testClayIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 1,
             'dependent_exemptions' => 1,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 11,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.clark'));

--- a/tests/Unit/Countries/US/Indiana/ClintonIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/ClintonIncomeTest.php
@@ -22,14 +22,14 @@ class ClintonIncomeTest extends TestCase
      */
     public function testClintonIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 12,
             'county_worked' => 11,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.clinton'));
@@ -44,14 +44,14 @@ class ClintonIncomeTest extends TestCase
 
     public function testClintonIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 12,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.clinton'));

--- a/tests/Unit/Countries/US/Indiana/CrawfordIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/CrawfordIncomeTest.php
@@ -23,14 +23,14 @@ class CrawfordIncomeTest extends TestCase
      */
     public function testCrawfordIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 13,
             'county_worked' => 12,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.crawford'));
@@ -45,14 +45,14 @@ class CrawfordIncomeTest extends TestCase
 
     public function testCrawfordIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 13,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.crawford'));

--- a/tests/Unit/Countries/US/Indiana/DaviessIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/DaviessIncomeTest.php
@@ -23,14 +23,14 @@ class DaviessIncomeTest extends TestCase
      */
     public function testDaviessIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 14,
             'county_worked' => 13,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.daviess'));
@@ -45,14 +45,14 @@ class DaviessIncomeTest extends TestCase
 
     public function testDaviessIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 14,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.daviess'));

--- a/tests/Unit/Countries/US/Indiana/DeKalbIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/DeKalbIncomeTest.php
@@ -23,14 +23,14 @@ class DeKalbIncomeTest extends TestCase
      */
     public function testDeKalbIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 17,
             'county_worked' => 16,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.dekalb'));
@@ -45,14 +45,14 @@ class DeKalbIncomeTest extends TestCase
 
     public function testDeKalbIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 17,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.dekalb'));

--- a/tests/Unit/Countries/US/Indiana/DearbornIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/DearbornIncomeTest.php
@@ -23,14 +23,14 @@ class DearbornIncomeTest extends TestCase
      */
     public function testDearbornIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 15,
             'county_worked' => 14,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.dearborn'));
@@ -45,14 +45,14 @@ class DearbornIncomeTest extends TestCase
 
     public function testDearbornIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 15,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.dearborn'));

--- a/tests/Unit/Countries/US/Indiana/DecaturIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/DecaturIncomeTest.php
@@ -23,14 +23,14 @@ class DecaturIncomeTest extends TestCase
      */
     public function testDecaturIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 16,
             'county_worked' => 15,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.decatur'));
@@ -45,14 +45,14 @@ class DecaturIncomeTest extends TestCase
 
     public function testDecaturIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 16,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.decatur'));

--- a/tests/Unit/Countries/US/Indiana/DelawareIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/DelawareIncomeTest.php
@@ -23,14 +23,14 @@ class DelawareIncomeTest extends TestCase
      */
     public function testDelawareIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 18,
             'county_worked' => 17,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.delaware'));
@@ -45,14 +45,14 @@ class DelawareIncomeTest extends TestCase
 
     public function testDelawareIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 18,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.delaware'));

--- a/tests/Unit/Countries/US/Indiana/DuboisIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/DuboisIncomeTest.php
@@ -23,14 +23,14 @@ class DuboisIncomeTest extends TestCase
      */
     public function testDuboisIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 19,
             'county_worked' => 18,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.dubois'));
@@ -45,14 +45,14 @@ class DuboisIncomeTest extends TestCase
 
     public function testDuboisIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 19,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.dubois'));

--- a/tests/Unit/Countries/US/Indiana/ElkhartIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/ElkhartIncomeTest.php
@@ -23,14 +23,14 @@ class ElkhartIncomeTest extends TestCase
      */
     public function testElkhartIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 20,
             'county_worked' => 19,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.elkhart'));
@@ -45,14 +45,14 @@ class ElkhartIncomeTest extends TestCase
 
     public function testElkhartIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 20,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.elkhart'));

--- a/tests/Unit/Countries/US/Indiana/FayetteIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/FayetteIncomeTest.php
@@ -23,14 +23,14 @@ class FayetteIncomeTest extends TestCase
      */
     public function testFayetteIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 21,
             'county_worked' => 20,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.fayette'));
@@ -45,14 +45,14 @@ class FayetteIncomeTest extends TestCase
 
     public function testFayetteIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 21,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.fayette'));

--- a/tests/Unit/Countries/US/Indiana/FloydIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/FloydIncomeTest.php
@@ -23,14 +23,14 @@ class FloydIncomeTest extends TestCase
      */
     public function testFloydIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 22,
             'county_worked' => 21,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.floyd'));
@@ -45,14 +45,14 @@ class FloydIncomeTest extends TestCase
 
     public function testFloydIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 22,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.floyd'));

--- a/tests/Unit/Countries/US/Indiana/FountainIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/FountainIncomeTest.php
@@ -23,14 +23,14 @@ class FountainIncomeTest extends TestCase
      */
     public function testFountainIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 23,
             'county_worked' => 22,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.fountain'));
@@ -45,14 +45,14 @@ class FountainIncomeTest extends TestCase
 
     public function testFountainIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 23,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.fountain'));

--- a/tests/Unit/Countries/US/Indiana/FranklinIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/FranklinIncomeTest.php
@@ -23,14 +23,14 @@ class FranklinIncomeTest extends TestCase
      */
     public function testFranklinIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 24,
             'county_worked' => 23,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.franklin'));
@@ -45,14 +45,14 @@ class FranklinIncomeTest extends TestCase
 
     public function testFranklinIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 24,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.franklin'));

--- a/tests/Unit/Countries/US/Indiana/FultonIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/FultonIncomeTest.php
@@ -23,14 +23,14 @@ class FultonIncomeTest extends TestCase
      */
     public function testFultonIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 25,
             'county_worked' => 24,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.fulton'));
@@ -45,14 +45,14 @@ class FultonIncomeTest extends TestCase
 
     public function testFultonIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 25,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.fulton'));

--- a/tests/Unit/Countries/US/Indiana/GibsonIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/GibsonIncomeTest.php
@@ -23,14 +23,14 @@ class GibsonIncomeTest extends TestCase
      */
     public function testGibsonIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 26,
             'county_worked' => 25,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.gibson'));
@@ -45,14 +45,14 @@ class GibsonIncomeTest extends TestCase
 
     public function testGibsonIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 26,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.gibson'));

--- a/tests/Unit/Countries/US/Indiana/GrantIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/GrantIncomeTest.php
@@ -32,14 +32,14 @@ class GrantIncomeTest extends TestCase
      */
     public function testGrantIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 2,
             'dependent_exemptions' => 1,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 27,
             'county_worked' => 26,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.grant'));
@@ -54,14 +54,14 @@ class GrantIncomeTest extends TestCase
 
     public function testGrantIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 2,
             'dependent_exemptions' => 1,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 27,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.grant'));

--- a/tests/Unit/Countries/US/Indiana/GreeneIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/GreeneIncomeTest.php
@@ -32,14 +32,14 @@ class GreeneIncomeTest extends TestCase
      */
     public function testGreeneIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 2,
             'dependent_exemptions' => 1,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 28,
             'county_worked' => 27,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.greene'));
@@ -54,14 +54,14 @@ class GreeneIncomeTest extends TestCase
 
     public function testGreeneIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 2,
             'dependent_exemptions' => 1,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 28,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.greene'));

--- a/tests/Unit/Countries/US/Indiana/HamiltonIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/HamiltonIncomeTest.php
@@ -23,14 +23,14 @@ class HamiltonIncomeTest extends TestCase
      */
     public function testHamiltonIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 29,
             'county_worked' => 28,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.hamilton'));
@@ -45,14 +45,14 @@ class HamiltonIncomeTest extends TestCase
 
     public function testHamiltonIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 29,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.hamilton'));

--- a/tests/Unit/Countries/US/Indiana/HancockIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/HancockIncomeTest.php
@@ -23,14 +23,14 @@ class HancockIncomeTest extends TestCase
      */
     public function testHancockIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 30,
             'county_worked' => 29,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.hancock'));
@@ -45,14 +45,14 @@ class HancockIncomeTest extends TestCase
 
     public function testHancockIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 30,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.hancock'));

--- a/tests/Unit/Countries/US/Indiana/HarrisonIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/HarrisonIncomeTest.php
@@ -23,14 +23,14 @@ class HarrisonIncomeTest extends TestCase
      */
     public function testHarrisonIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 31,
             'county_worked' => 30,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.harrison'));
@@ -45,14 +45,14 @@ class HarrisonIncomeTest extends TestCase
 
     public function testHarrisonIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 31,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.harrison'));

--- a/tests/Unit/Countries/US/Indiana/HendricksIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/HendricksIncomeTest.php
@@ -23,14 +23,14 @@ class HendricksIncomeTest extends TestCase
      */
     public function testHendricksIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 32,
             'county_worked' => 31,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.hendricks'));
@@ -45,14 +45,14 @@ class HendricksIncomeTest extends TestCase
 
     public function testHendricksIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 32,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.hendricks'));

--- a/tests/Unit/Countries/US/Indiana/HenryIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/HenryIncomeTest.php
@@ -23,14 +23,14 @@ class HenryIncomeTest extends TestCase
      */
     public function testHenryIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 33,
             'county_worked' => 32,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.henry'));
@@ -45,14 +45,14 @@ class HenryIncomeTest extends TestCase
 
     public function testHenryIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 33,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.henry'));

--- a/tests/Unit/Countries/US/Indiana/HowardIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/HowardIncomeTest.php
@@ -23,14 +23,14 @@ class HowardIncomeTest extends TestCase
      */
     public function testHowardIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 34,
             'county_worked' => 33,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.howard'));
@@ -45,14 +45,14 @@ class HowardIncomeTest extends TestCase
 
     public function testHowardIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 34,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.howard'));

--- a/tests/Unit/Countries/US/Indiana/HuntingtonIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/HuntingtonIncomeTest.php
@@ -23,14 +23,14 @@ class HuntingtonIncomeTest extends TestCase
      */
     public function testHuntingtonIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 35,
             'county_worked' => 34,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.huntington'));
@@ -45,14 +45,14 @@ class HuntingtonIncomeTest extends TestCase
 
     public function testHuntingtonIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 35,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.huntington'));

--- a/tests/Unit/Countries/US/Indiana/IndianaIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/IndianaIncomeTest.php
@@ -153,14 +153,14 @@ class IndianaIncomeTest extends TestCase
     private function calculateTaxes(int $earnings, int $personal_exemptions, int $dependent_exemptions,
                                     bool $exempt = false, int $additional_withholding = 0): TaxResults
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => $personal_exemptions,
             'dependent_exemptions' => $dependent_exemptions,
             'exempt' => $exempt,
             'additional_withholding' => $additional_withholding,
             'county_lived' => 22,
             'county_worked' => 33,
-        ], $this->user);
+        ]);
 
         return $this->taxes->calculate(function (Taxes $taxes) use ($earnings) {
             $taxes->setHomeLocation($this->getLocation('us.indiana'));

--- a/tests/Unit/Countries/US/Indiana/JacksonIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/JacksonIncomeTest.php
@@ -23,14 +23,14 @@ class JacksonIncomeTest extends TestCase
      */
     public function testJacksonIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 36,
             'county_worked' => 35,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.jackson'));
@@ -45,14 +45,14 @@ class JacksonIncomeTest extends TestCase
 
     public function testJacksonIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 36,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.jackson'));

--- a/tests/Unit/Countries/US/Indiana/JasperIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/JasperIncomeTest.php
@@ -23,14 +23,14 @@ class JasperIncomeTest extends TestCase
      */
     public function testJasperIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 37,
             'county_worked' => 36,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.jasper'));
@@ -45,14 +45,14 @@ class JasperIncomeTest extends TestCase
 
     public function testJasperIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 37,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.jasper'));

--- a/tests/Unit/Countries/US/Indiana/JayIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/JayIncomeTest.php
@@ -23,14 +23,14 @@ class JayIncomeTest extends TestCase
      */
     public function testJayIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 38,
             'county_worked' => 37,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.jay'));
@@ -45,14 +45,14 @@ class JayIncomeTest extends TestCase
 
     public function testJayIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 38,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.jay'));

--- a/tests/Unit/Countries/US/Indiana/JeffersonIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/JeffersonIncomeTest.php
@@ -23,14 +23,14 @@ class JeffersonIncomeTest extends TestCase
      */
     public function testJeffersonIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 39,
             'county_worked' => 38,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.jefferson'));
@@ -45,14 +45,14 @@ class JeffersonIncomeTest extends TestCase
 
     public function testJeffersonIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 39,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.jefferson'));

--- a/tests/Unit/Countries/US/Indiana/JenningsIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/JenningsIncomeTest.php
@@ -23,14 +23,14 @@ class JenningsIncomeTest extends TestCase
      */
     public function testJenningsIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 40,
             'county_worked' => 39,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.jennings'));
@@ -45,14 +45,14 @@ class JenningsIncomeTest extends TestCase
 
     public function testJenningsIncomeWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 40,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.jennings'));

--- a/tests/Unit/Countries/US/Indiana/JohnsonIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/JohnsonIncomeTest.php
@@ -23,14 +23,14 @@ class JohnsonIncomeTest extends TestCase
      */
     public function testJohnsonIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 41,
             'county_worked' => 40,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.johnson'));
@@ -45,14 +45,14 @@ class JohnsonIncomeTest extends TestCase
 
     public function testJohnsonIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 41,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.johnson'));

--- a/tests/Unit/Countries/US/Indiana/KnoxIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/KnoxIncomeTest.php
@@ -23,14 +23,14 @@ class KnoxIncomeTest extends TestCase
      */
     public function testKnoxIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 42,
             'county_worked' => 41,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.knox'));
@@ -45,14 +45,14 @@ class KnoxIncomeTest extends TestCase
 
     public function testKnoxIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 42,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.knox'));

--- a/tests/Unit/Countries/US/Indiana/KosciuskoIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/KosciuskoIncomeTest.php
@@ -23,14 +23,14 @@ class KosciuskoIncomeTest extends TestCase
      */
     public function testKosciuskoIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 43,
             'county_worked' => 42,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.kosciusko'));
@@ -45,14 +45,14 @@ class KosciuskoIncomeTest extends TestCase
 
     public function testKosciuskoIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 43,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.kosciusko'));

--- a/tests/Unit/Countries/US/Indiana/LaGrangeIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/LaGrangeIncomeTest.php
@@ -23,14 +23,14 @@ class LaGrangeIncomeTest extends TestCase
      */
     public function testLaGrangeIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 44,
             'county_worked' => 43,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.lagrange'));
@@ -45,14 +45,14 @@ class LaGrangeIncomeTest extends TestCase
 
     public function testLaGrangeIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 44,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.lagrange'));

--- a/tests/Unit/Countries/US/Indiana/LaPorteIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/LaPorteIncomeTest.php
@@ -23,14 +23,14 @@ class LaPorteIncomeTest extends TestCase
      */
     public function testLaPorteIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 46,
             'county_worked' => 45,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.laporte'));
@@ -45,14 +45,14 @@ class LaPorteIncomeTest extends TestCase
 
     public function testLaPorteIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 46,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.laporte'));

--- a/tests/Unit/Countries/US/Indiana/LakeIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/LakeIncomeTest.php
@@ -23,14 +23,14 @@ class LakeIncomeTest extends TestCase
      */
     public function testLakeIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 45,
             'county_worked' => 44,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.lake'));
@@ -45,14 +45,14 @@ class LakeIncomeTest extends TestCase
 
     public function testLakeIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 45,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.lake'));

--- a/tests/Unit/Countries/US/Indiana/LawrenceIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/LawrenceIncomeTest.php
@@ -23,14 +23,14 @@ class LawrenceIncomeTest extends TestCase
      */
     public function testLawrenceIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 47,
             'county_worked' => 46,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.lawrence'));
@@ -45,14 +45,14 @@ class LawrenceIncomeTest extends TestCase
 
     public function testLawrenceIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 47,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.lawrence'));

--- a/tests/Unit/Countries/US/Indiana/MadisonIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/MadisonIncomeTest.php
@@ -23,14 +23,14 @@ class MadisonIncomeTest extends TestCase
      */
     public function testMadisonIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 48,
             'county_worked' => 47,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.madison'));
@@ -45,14 +45,14 @@ class MadisonIncomeTest extends TestCase
 
     public function testMadisonIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 48,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.madison'));

--- a/tests/Unit/Countries/US/Indiana/MarionIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/MarionIncomeTest.php
@@ -32,14 +32,14 @@ class MarionIncomeTest extends TestCase
      */
     public function testMarionIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 1,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 49,
             'county_worked' => 48,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.marion'));
@@ -54,14 +54,14 @@ class MarionIncomeTest extends TestCase
 
     public function testMarionIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 1,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 49,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.marion'));

--- a/tests/Unit/Countries/US/Indiana/MarshallIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/MarshallIncomeTest.php
@@ -23,14 +23,14 @@ class MarshallIncomeTest extends TestCase
      */
     public function testMarshallIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 50,
             'county_worked' => 49,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.marshall'));
@@ -45,14 +45,14 @@ class MarshallIncomeTest extends TestCase
 
     public function testMarshallIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 50,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.marshall'));

--- a/tests/Unit/Countries/US/Indiana/MartinIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/MartinIncomeTest.php
@@ -32,14 +32,14 @@ class MartinIncomeTest extends TestCase
      */
     public function testMartinIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 1,
             'dependent_exemptions' => 1,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 51,
             'county_worked' => 50,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.martin'));
@@ -54,14 +54,14 @@ class MartinIncomeTest extends TestCase
 
     public function testMartinIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 1,
             'dependent_exemptions' => 1,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 51,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.martin'));

--- a/tests/Unit/Countries/US/Indiana/MiamiIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/MiamiIncomeTest.php
@@ -32,14 +32,14 @@ class MiamiIncomeTest extends TestCase
      */
     public function testMiamiIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 2,
             'dependent_exemptions' => 1,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 52,
             'county_worked' => 51,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.miami'));
@@ -54,14 +54,14 @@ class MiamiIncomeTest extends TestCase
 
     public function testMiamiIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 2,
             'dependent_exemptions' => 1,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 52,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.miami'));

--- a/tests/Unit/Countries/US/Indiana/MonroeIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/MonroeIncomeTest.php
@@ -23,14 +23,14 @@ class MonroeIncomeTest extends TestCase
      */
     public function testMonroeIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 53,
             'county_worked' => 52,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.monroe'));
@@ -45,14 +45,14 @@ class MonroeIncomeTest extends TestCase
 
     public function testMonroeIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 53,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.monroe'));

--- a/tests/Unit/Countries/US/Indiana/MontgomeryIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/MontgomeryIncomeTest.php
@@ -23,14 +23,14 @@ class MontgomeryIncomeTest extends TestCase
      */
     public function testMontgomeryIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 54,
             'county_worked' => 53,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.montgomery'));
@@ -45,14 +45,14 @@ class MontgomeryIncomeTest extends TestCase
 
     public function testMontgomeryIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 54,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.montgomery'));

--- a/tests/Unit/Countries/US/Indiana/MorganIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/MorganIncomeTest.php
@@ -23,14 +23,14 @@ class MorganIncomeTest extends TestCase
      */
     public function testMorganIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 55,
             'county_worked' => 54,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.morgan'));
@@ -45,14 +45,14 @@ class MorganIncomeTest extends TestCase
 
     public function testMorganIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 55,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.morgan'));

--- a/tests/Unit/Countries/US/Indiana/NewtonIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/NewtonIncomeTest.php
@@ -23,14 +23,14 @@ class NewtonIncomeTest extends TestCase
      */
     public function testNewtonIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 56,
             'county_worked' => 55,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.newton'));
@@ -45,14 +45,14 @@ class NewtonIncomeTest extends TestCase
 
     public function testNewtonIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 56,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.newton'));

--- a/tests/Unit/Countries/US/Indiana/NobleIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/NobleIncomeTest.php
@@ -23,14 +23,14 @@ class NobleIncomeTest extends TestCase
      */
     public function testNobleIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 57,
             'county_worked' => 56,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.noble'));
@@ -45,14 +45,14 @@ class NobleIncomeTest extends TestCase
 
     public function testNobleIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 57,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.noble'));

--- a/tests/Unit/Countries/US/Indiana/OhioIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/OhioIncomeTest.php
@@ -23,14 +23,14 @@ class OhioIncomeTest extends TestCase
      */
     public function testOhioIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 58,
             'county_worked' => 57,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.ohio'));
@@ -45,14 +45,14 @@ class OhioIncomeTest extends TestCase
 
     public function testOhioIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 58,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.ohio'));

--- a/tests/Unit/Countries/US/Indiana/OrangeIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/OrangeIncomeTest.php
@@ -23,14 +23,14 @@ class OrangeIncomeTest extends TestCase
      */
     public function testOrangeIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 59,
             'county_worked' => 58,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.orange'));
@@ -45,14 +45,14 @@ class OrangeIncomeTest extends TestCase
 
     public function testOrangeIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 59,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.orange'));

--- a/tests/Unit/Countries/US/Indiana/OwenIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/OwenIncomeTest.php
@@ -23,14 +23,14 @@ class OwenIncomeTest extends TestCase
      */
     public function testOwenIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 60,
             'county_worked' => 59,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.owen'));
@@ -45,14 +45,14 @@ class OwenIncomeTest extends TestCase
 
     public function testOwenIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 60,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.owen'));

--- a/tests/Unit/Countries/US/Indiana/ParkeIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/ParkeIncomeTest.php
@@ -23,14 +23,14 @@ class ParkeIncomeTest extends TestCase
      */
     public function testParkeIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 61,
             'county_worked' => 60,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.parke'));
@@ -45,14 +45,14 @@ class ParkeIncomeTest extends TestCase
 
     public function testParkeIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 61,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.parke'));

--- a/tests/Unit/Countries/US/Indiana/PerryIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/PerryIncomeTest.php
@@ -23,14 +23,14 @@ class PerryIncomeTest extends TestCase
      */
     public function testPerryIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 62,
             'county_worked' => 61,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.perry'));
@@ -45,14 +45,14 @@ class PerryIncomeTest extends TestCase
 
     public function testPerryIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 62,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.perry'));

--- a/tests/Unit/Countries/US/Indiana/PikeIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/PikeIncomeTest.php
@@ -23,14 +23,14 @@ class PikeIncomeTest extends TestCase
      */
     public function testPikeIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 63,
             'county_worked' => 62,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.pike'));
@@ -45,14 +45,14 @@ class PikeIncomeTest extends TestCase
 
     public function testPikeIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 63,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.pike'));

--- a/tests/Unit/Countries/US/Indiana/PorterIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/PorterIncomeTest.php
@@ -23,14 +23,14 @@ class PorterIncomeTest extends TestCase
      */
     public function testPorterIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 64,
             'county_worked' => 63,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.porter'));
@@ -45,14 +45,14 @@ class PorterIncomeTest extends TestCase
 
     public function testPorterIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 64,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.porter'));

--- a/tests/Unit/Countries/US/Indiana/PoseyIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/PoseyIncomeTest.php
@@ -23,14 +23,14 @@ class PoseyIncomeTest extends TestCase
      */
     public function testPoseyIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 65,
             'county_worked' => 64,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.posey'));
@@ -45,14 +45,14 @@ class PoseyIncomeTest extends TestCase
 
     public function testPoseyIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 65,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.posey'));

--- a/tests/Unit/Countries/US/Indiana/PulaskiIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/PulaskiIncomeTest.php
@@ -23,14 +23,14 @@ class PulaskiIncomeTest extends TestCase
      */
     public function testPulaskiIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 66,
             'county_worked' => 65,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.pulaski'));
@@ -45,14 +45,14 @@ class PulaskiIncomeTest extends TestCase
 
     public function testPulaskiIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 66,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.pulaski'));

--- a/tests/Unit/Countries/US/Indiana/PutnamIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/PutnamIncomeTest.php
@@ -23,14 +23,14 @@ class PutnamIncomeTest extends TestCase
      */
     public function testPutnamIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 67,
             'county_worked' => 66,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.putnam'));
@@ -45,14 +45,14 @@ class PutnamIncomeTest extends TestCase
 
     public function testPutnamIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 67,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.putnam'));

--- a/tests/Unit/Countries/US/Indiana/RandolphIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/RandolphIncomeTest.php
@@ -23,14 +23,14 @@ class RandolphIncomeTest extends TestCase
      */
     public function testRandolphIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 68,
             'county_worked' => 67,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.randolph'));
@@ -45,14 +45,14 @@ class RandolphIncomeTest extends TestCase
 
     public function testRandolphIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 68,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.randolph'));

--- a/tests/Unit/Countries/US/Indiana/RipleyIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/RipleyIncomeTest.php
@@ -23,14 +23,14 @@ class RipleyIncomeTest extends TestCase
      */
     public function testRipleyIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 69,
             'county_worked' => 68,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.ripley'));
@@ -45,14 +45,14 @@ class RipleyIncomeTest extends TestCase
 
     public function testRipleyIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 69,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.ripley'));

--- a/tests/Unit/Countries/US/Indiana/RushIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/RushIncomeTest.php
@@ -23,14 +23,14 @@ class RushIncomeTest extends TestCase
      */
     public function testRushIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 70,
             'county_worked' => 69,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.rush'));
@@ -45,14 +45,14 @@ class RushIncomeTest extends TestCase
 
     public function testRushIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 70,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.rush'));

--- a/tests/Unit/Countries/US/Indiana/ScottIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/ScottIncomeTest.php
@@ -23,14 +23,14 @@ class ScottIncomeTest extends TestCase
      */
     public function testScottIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 72,
             'county_worked' => 70,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.scott'));
@@ -45,14 +45,14 @@ class ScottIncomeTest extends TestCase
 
     public function testScottIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 72,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.scott'));

--- a/tests/Unit/Countries/US/Indiana/ShelbyIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/ShelbyIncomeTest.php
@@ -23,14 +23,14 @@ class ShelbyIncomeTest extends TestCase
      */
     public function testShelbyIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 73,
             'county_worked' => 72,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.shelby'));
@@ -45,14 +45,14 @@ class ShelbyIncomeTest extends TestCase
 
     public function testShelbyIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 73,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.shelby'));

--- a/tests/Unit/Countries/US/Indiana/SpencerIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/SpencerIncomeTest.php
@@ -23,14 +23,14 @@ class SpencerIncomeTest extends TestCase
      */
     public function testSpencerIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 74,
             'county_worked' => 73,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.spencer'));
@@ -45,14 +45,14 @@ class SpencerIncomeTest extends TestCase
 
     public function testSpencerIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 74,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.spencer'));

--- a/tests/Unit/Countries/US/Indiana/StJosephIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/StJosephIncomeTest.php
@@ -23,14 +23,14 @@ class StJosephIncomeTest extends TestCase
      */
     public function testJosephIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 71,
             'county_worked' => 72,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.stjoseph'));
@@ -45,14 +45,14 @@ class StJosephIncomeTest extends TestCase
 
     public function testJosephIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 71,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.stjoseph'));

--- a/tests/Unit/Countries/US/Indiana/StarkeIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/StarkeIncomeTest.php
@@ -23,14 +23,14 @@ class StarkeIncomeTest extends TestCase
      */
     public function testStarkeIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 75,
             'county_worked' => 74,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.starke'));
@@ -45,14 +45,14 @@ class StarkeIncomeTest extends TestCase
 
     public function testStarkeIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 75,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.starke'));

--- a/tests/Unit/Countries/US/Indiana/SteubenIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/SteubenIncomeTest.php
@@ -23,14 +23,14 @@ class SteubenIncomeTest extends TestCase
      */
     public function testSteubenIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 76,
             'county_worked' => 75,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.steuben'));
@@ -45,14 +45,14 @@ class SteubenIncomeTest extends TestCase
 
     public function testSteubenIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 76,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.steuben'));

--- a/tests/Unit/Countries/US/Indiana/SullivanIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/SullivanIncomeTest.php
@@ -23,14 +23,14 @@ class SullivanIncomeTest extends TestCase
      */
     public function testSullivanIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 77,
             'county_worked' => 76,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.sullivan'));
@@ -45,14 +45,14 @@ class SullivanIncomeTest extends TestCase
 
     public function testSullivanIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 77,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.sullivan'));

--- a/tests/Unit/Countries/US/Indiana/SwitzerlandIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/SwitzerlandIncomeTest.php
@@ -23,14 +23,14 @@ class SwitzerlandIncomeTest extends TestCase
      */
     public function testSwitzerlandIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 78,
             'county_worked' => 77,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.switzerland'));
@@ -45,14 +45,14 @@ class SwitzerlandIncomeTest extends TestCase
 
     public function testSwitzerlandIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 78,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.switzerland'));

--- a/tests/Unit/Countries/US/Indiana/TippecanoeIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/TippecanoeIncomeTest.php
@@ -32,14 +32,14 @@ class TippecanoeIncomeTest extends TestCase
      */
     public function testTippecanoeIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 1,
             'dependent_exemptions' => 2,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 79,
             'county_worked' => 78,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.tippecanoe'));
@@ -54,14 +54,14 @@ class TippecanoeIncomeTest extends TestCase
 
     public function testTippecanoeIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 1,
             'dependent_exemptions' => 2,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 79,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.tippecanoe'));

--- a/tests/Unit/Countries/US/Indiana/TiptonIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/TiptonIncomeTest.php
@@ -23,14 +23,14 @@ class TiptonIncomeTest extends TestCase
      */
     public function testTiptonIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 80,
             'county_worked' => 79,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.tipton'));
@@ -45,14 +45,14 @@ class TiptonIncomeTest extends TestCase
 
     public function testTiptonIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 80,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.tipton'));

--- a/tests/Unit/Countries/US/Indiana/UnionIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/UnionIncomeTest.php
@@ -23,14 +23,14 @@ class UnionIncomeTest extends TestCase
      */
     public function testUnionIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 81,
             'county_worked' => 80,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.union'));
@@ -45,14 +45,14 @@ class UnionIncomeTest extends TestCase
 
     public function testUnionIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 81,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.union'));

--- a/tests/Unit/Countries/US/Indiana/VanderburghIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/VanderburghIncomeTest.php
@@ -33,14 +33,14 @@ class VanderburghIncomeTest extends TestCase
      */
     public function testVanderburghIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 1,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 82,
             'county_worked' => 81,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.vanderburgh'));
@@ -55,14 +55,14 @@ class VanderburghIncomeTest extends TestCase
 
     public function testVanderburghIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 1,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 82,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.vanderburgh'));

--- a/tests/Unit/Countries/US/Indiana/VermillionIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/VermillionIncomeTest.php
@@ -23,14 +23,14 @@ class VermillionIncomeTest extends TestCase
      */
     public function testVermillionIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 83,
             'county_worked' => 82,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.vermillion'));
@@ -45,14 +45,14 @@ class VermillionIncomeTest extends TestCase
 
     public function testVermillionIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 83,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.vermillion'));

--- a/tests/Unit/Countries/US/Indiana/VigoIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/VigoIncomeTest.php
@@ -23,14 +23,14 @@ class VigoIncomeTest extends TestCase
      */
     public function testVigoIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 84,
             'county_worked' => 83,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.vigo'));
@@ -45,14 +45,14 @@ class VigoIncomeTest extends TestCase
 
     public function testVigoIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 84,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.vigo'));

--- a/tests/Unit/Countries/US/Indiana/WabashIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/WabashIncomeTest.php
@@ -23,14 +23,14 @@ class WabashIncomeTest extends TestCase
      */
     public function testWabashIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 85,
             'county_worked' => 84,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.wabash'));
@@ -45,14 +45,14 @@ class WabashIncomeTest extends TestCase
 
     public function testWabashIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 85,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.wabash'));

--- a/tests/Unit/Countries/US/Indiana/WarrenIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/WarrenIncomeTest.php
@@ -23,14 +23,14 @@ class WarrenIncomeTest extends TestCase
      */
     public function testWarrenIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 86,
             'county_worked' => 85,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.warren'));
@@ -45,14 +45,14 @@ class WarrenIncomeTest extends TestCase
 
     public function testWarrenIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 86,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.warren'));

--- a/tests/Unit/Countries/US/Indiana/WarrickIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/WarrickIncomeTest.php
@@ -23,14 +23,14 @@ class WarrickIncomeTest extends TestCase
      */
     public function testWarrickIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 87,
             'county_worked' => 86,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.warrick'));
@@ -45,14 +45,14 @@ class WarrickIncomeTest extends TestCase
 
     public function testWarrickIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 87,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.warrick'));

--- a/tests/Unit/Countries/US/Indiana/WashingtonIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/WashingtonIncomeTest.php
@@ -23,14 +23,14 @@ class WashingtonIncomeTest extends TestCase
      */
     public function testWashingtonIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 88,
             'county_worked' => 87,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.washington'));
@@ -45,14 +45,14 @@ class WashingtonIncomeTest extends TestCase
 
     public function testWashingtonIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 88,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.washington'));

--- a/tests/Unit/Countries/US/Indiana/WayneIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/WayneIncomeTest.php
@@ -23,14 +23,14 @@ class WayneIncomeTest extends TestCase
      */
     public function testWayneIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 89,
             'county_worked' => 88,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.wayne'));
@@ -45,14 +45,14 @@ class WayneIncomeTest extends TestCase
 
     public function testWayneIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 89,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.wayne'));

--- a/tests/Unit/Countries/US/Indiana/WellsIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/WellsIncomeTest.php
@@ -23,14 +23,14 @@ class WellsIncomeTest extends TestCase
      */
     public function testWellsIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 90,
             'county_worked' => 89,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.wells'));
@@ -45,14 +45,14 @@ class WellsIncomeTest extends TestCase
 
     public function testWellsIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 90,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.wells'));

--- a/tests/Unit/Countries/US/Indiana/WhiteIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/WhiteIncomeTest.php
@@ -23,14 +23,14 @@ class WhiteIncomeTest extends TestCase
      */
     public function testWhiteIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 91,
             'county_worked' => 90,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.white'));
@@ -45,14 +45,14 @@ class WhiteIncomeTest extends TestCase
 
     public function testWhiteIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 91,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.white'));

--- a/tests/Unit/Countries/US/Indiana/WhitleyIncomeTest.php
+++ b/tests/Unit/Countries/US/Indiana/WhitleyIncomeTest.php
@@ -23,14 +23,14 @@ class WhitleyIncomeTest extends TestCase
      */
     public function testWhitleyIncome(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 92,
             'county_worked' => 91,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.whitley'));
@@ -45,14 +45,14 @@ class WhitleyIncomeTest extends TestCase
 
     public function testWhitleyIncomeCountyWorked(): void
     {
-        IndianaIncomeTaxInformation::createForUser([
+        IndianaIncomeTaxInformation::forUser($this->user)->update([
             'personal_exemptions' => 0,
             'dependent_exemptions' => 0,
             'exempt' => false,
             'additional_withholding' => 0,
             'county_lived' => 0,
             'county_worked' => 92,
-        ], $this->user);
+        ]);
 
         $results = $this->taxes->calculate(function (Taxes $taxes) {
             $taxes->setHomeLocation($this->getLocation('us.indiana.whitley'));

--- a/tests/Unit/Countries/US/Virginia/VirginiaIncomeTest.php
+++ b/tests/Unit/Countries/US/Virginia/VirginiaIncomeTest.php
@@ -307,11 +307,11 @@ class VirginiaIncomeTest extends TestCase
     private function calculateTaxes(int $exemptions, int $other_exemptions,
                                     float $earnings, bool $exempt = false): TaxResults
     {
-        VirginiaIncomeTaxInformation::createForUser([
+        VirginiaIncomeTaxInformation::forUser($this->user)->update([
             'exemptions' => $exemptions,
             'sixty_five_plus_or_blind_exemptions' => $other_exemptions,
             'exempt' => $exempt,
-        ], $this->user);
+        ]);
 
         return $this->taxes->calculate(function (Taxes $taxes) use ($earnings) {
             $taxes->setHomeLocation($this->getLocation('us.virginia'));


### PR DESCRIPTION
### Ticket
[Speed up laravel taxes tests](https://spurjob.atlassian.net/browse/ACC-310)

### Changes
* Run migrations outside of test, use `php init_db.php` from the root. (There is probably a much better way to do this)
* Update TestCase to use transactions and not migrate the database
* Fix tests to update existing tax information for user instead of creating a new one