### PR TITLE
ACC-322 - Add nyc allowances and nyc/yonkers additional withholdings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
   postgresql: '9.6'
   apt:
     packages:
-      - postgresql-9.6-postgis-2.3
+      - postgresql-9.6-postgis-2.4
 
 before_install:
   - sudo mount -o remount,size=50% /var/ramfs

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
   postgresql: '9.6'
   apt:
     packages:
-      - postgresql-9.6-postgis-2.4
+      - postgresql-9.6-postgis-2.3
 
 before_install:
   - sudo mount -o remount,size=50% /var/ramfs

--- a/src/Countries/US/NewYork/NewYorkCity/V20190101/NewYorkCity.php
+++ b/src/Countries/US/NewYork/NewYorkCity/V20190101/NewYorkCity.php
@@ -42,9 +42,14 @@ class NewYorkCity extends BaseNewYorkCity
         return static::BRACKETS;
     }
 
+    public function getAdditionalWithholding()
+    {
+        return max(min($this->payroll->getNetEarnings(), $this->tax_information->nyc_additional_withholding), 0);
+    }
+
     private function getExemptionAllowance()
     {
-        return $this->tax_information->exemptions * static::EXEMPTION_ALLOWANCE_AMOUNT;
+        return $this->tax_information->nyc_allowances * static::EXEMPTION_ALLOWANCE_AMOUNT;
     }
 
     public function getDeductionAllowance()

--- a/src/Countries/US/NewYork/NewYorkIncome/V20190101/NewYorkIncome.php
+++ b/src/Countries/US/NewYork/NewYorkIncome/V20190101/NewYorkIncome.php
@@ -70,9 +70,14 @@ class NewYorkIncome extends BaseNewYorkIncome
         }
     }
 
+    public function getAdditionalWithholding()
+    {
+        return max(min($this->payroll->getNetEarnings(), $this->tax_information->ny_additional_withholding), 0);
+    }
+
     private function getExemptionAllowance()
     {
-        return $this->tax_information->exemptions * self::EXEMPTION_ALLOWANCE_AMOUNT;
+        return $this->tax_information->ny_allowances * self::EXEMPTION_ALLOWANCE_AMOUNT;
     }
 
     public function getDeductionAllowance()

--- a/src/Countries/US/NewYork/Yonkers/Yonkers.php
+++ b/src/Countries/US/NewYork/Yonkers/Yonkers.php
@@ -3,6 +3,8 @@
 namespace Appleton\Taxes\Countries\US\NewYork\Yonkers;
 
 use Appleton\Taxes\Classes\BaseLocalIncome;
+use Appleton\Taxes\Classes\Payroll;
+use Appleton\Taxes\Models\Countries\US\NewYork\NewYorkIncomeTaxInformation;
 
 abstract class Yonkers extends BaseLocalIncome
 {
@@ -14,5 +16,9 @@ abstract class Yonkers extends BaseLocalIncome
         self::FILING_MARRIED => 'FILING_MARRIED',
     ];
 
-    public $tax_total = 0;
+    public function __construct(NewYorkIncomeTaxInformation $tax_information, Payroll $payroll)
+    {
+        parent::__construct($payroll);
+        $this->tax_information = $tax_information;
+    }
 }

--- a/src/Models/Countries/US/NewYork/NewYorkIncomeTaxInformation.php
+++ b/src/Models/Countries/US/NewYork/NewYorkIncomeTaxInformation.php
@@ -12,8 +12,12 @@ class NewYorkIncomeTaxInformation extends BaseTaxInformationModel
     public static function getDefault()
     {
         $tax_information = new self();
-        $tax_information->additional_withholding = 0;
-        $tax_information->exemptions = 0;
+        $tax_information->ny_additional_withholding = 0;
+        $tax_information->nyc_additional_withholding = 0;
+        $tax_information->yonkers_additional_withholding = 0;
+        $tax_information->ny_allowances = 0;
+        $tax_information->nyc_allowances = 0;
+        $tax_information->yonkers_allowances = 0;
         $tax_information->filing_status = NewYorkIncome::FILING_SINGLE;
         $tax_information->exempt = false;
         return $tax_information;

--- a/src/Models/Countries/US/NewYork/NewYorkIncomeTaxInformation.php
+++ b/src/Models/Countries/US/NewYork/NewYorkIncomeTaxInformation.php
@@ -17,7 +17,6 @@ class NewYorkIncomeTaxInformation extends BaseTaxInformationModel
         $tax_information->yonkers_additional_withholding = 0;
         $tax_information->ny_allowances = 0;
         $tax_information->nyc_allowances = 0;
-        $tax_information->yonkers_allowances = 0;
         $tax_information->filing_status = NewYorkIncome::FILING_SINGLE;
         $tax_information->exempt = false;
         return $tax_information;

--- a/src/migrations/2019_08_01_000000_update_ny_local_fields.php
+++ b/src/migrations/2019_08_01_000000_update_ny_local_fields.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class UpdateNyLocalFields extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('new_york_income_tax_information', static function (Blueprint $table) {
+            $table->renameColumn('additional_withholding', 'ny_additional_withholding');
+            $table->renameColumn('exemptions', 'ny_allowances');
+
+            $table->integer('nyc_additional_withholding')->default(0);
+            $table->integer('yonkers_additional_withholding')->default(0);
+            $table->integer('nyc_allowances')->default(0);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('new_york_income_tax_information', static function (Blueprint $table) {
+            $table->renameColumn('ny_additional_withholding', 'additional_withholding');
+            $table->renameColumn('ny_allowances', 'exemptions');
+            $table->dropColumn(
+                'nyc_additional_withholding',
+                'yonkers_additional_withholding',
+                'nyc_allowances'
+            );
+        });
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -193,8 +193,8 @@ class TestCase extends BaseTestCase
         ], $this->user);
 
         NewYorkIncomeTaxInformation::createForUser([
-            'additional_withholding' => 0,
-            'exemptions' => 0,
+            'ny_additional_withholding' => 0,
+            'ny_allowances' => 0,
             'filing_status' => NewYorkIncome::FILING_SINGLE,
         ], $this->user);
 

--- a/tests/Unit/Countries/US/NewYork/NewYorkCityTest.php
+++ b/tests/Unit/Countries/US/NewYork/NewYorkCityTest.php
@@ -11,7 +11,8 @@ class NewYorkCityTest extends \TestCase
     /**
      * @dataProvider provideTestData
      */
-    public function testNewYorkCity($date, $filing_status, $exemptions, $earnings, $result)
+    public function testNewYorkCity($date, $filing_status, $exemptions,
+                                    $additional_withholding, $earnings, $result)
     {
         Carbon::setTestNow(
             Carbon::parse($date, 'America/Chicago')->setTimezone('UTC')
@@ -19,8 +20,12 @@ class NewYorkCityTest extends \TestCase
 
         NewYorkIncomeTaxInformation::forUser($this->user)
             ->update([
-                'exemptions' => $exemptions,
+                'nyc_allowances' => $exemptions,
+                'ny_allowances' => 10, // should not be used
                 'filing_status' => $filing_status,
+                'nyc_additional_withholding' => $additional_withholding,
+                'ny_additional_withholding' => 10, // should not be used
+                'yonkers_additional_withholding' => 10, // should not be used
             ]);
 
         $results = $this->taxes->calculate(function ($taxes) use ($earnings) {
@@ -41,6 +46,7 @@ class NewYorkCityTest extends \TestCase
                 'January 1, 2019 8am',
                 NewYorkIncome::FILING_SINGLE,
                 4,
+                0,
                 1000,
                 29.42,
             ],
@@ -48,6 +54,7 @@ class NewYorkCityTest extends \TestCase
                 'January 1, 2019 8am',
                 NewYorkIncome::FILING_SINGLE,
                 2,
+                0,
                 500,
                 10.50,
             ],
@@ -55,6 +62,7 @@ class NewYorkCityTest extends \TestCase
                 'January 1, 2019 8am',
                 NewYorkIncome::FILING_SINGLE,
                 12,
+                0,
                 500,
                 3.72,
             ],
@@ -62,6 +70,7 @@ class NewYorkCityTest extends \TestCase
                 'January 1, 2019 8am',
                 NewYorkIncome::FILING_SINGLE,
                 3,
+                0,
                 700,
                 17.77,
             ],
@@ -69,6 +78,7 @@ class NewYorkCityTest extends \TestCase
                 'January 1, 2019 8am',
                 NewYorkIncome::FILING_SINGLE,
                 5,
+                0,
                 900,
                 24.47,
             ],
@@ -76,6 +86,7 @@ class NewYorkCityTest extends \TestCase
                 'January 1, 2019 8am',
                 NewYorkIncome::FILING_SINGLE,
                 2,
+                0,
                 2000,
                 73.24,
             ],
@@ -83,8 +94,17 @@ class NewYorkCityTest extends \TestCase
                 'January 1, 2019 8am',
                 NewYorkIncome::FILING_SINGLE,
                 11,
+                0,
                 1000,
                 23.83,
+            ],
+            '7' => [
+                'January 1, 2019 8am',
+                NewYorkIncome::FILING_SINGLE,
+                11,
+                10,
+                1000,
+                33.83,
             ],
         ];
     }

--- a/tests/Unit/Countries/US/NewYork/NewYorkIncomeTest.php
+++ b/tests/Unit/Countries/US/NewYork/NewYorkIncomeTest.php
@@ -10,7 +10,8 @@ class NewYorkIncomeTest extends \TestCase
     /**
      * @dataProvider provideTestData
      */
-    public function testNewYorkIncome($date, $filing_status, $exemptions, $earnings, $result)
+    public function testNewYorkIncome($date, $filing_status, $allowances,
+                                      $additional_withholding, $earnings, $result)
     {
         Carbon::setTestNow(
             Carbon::parse($date, 'America/Chicago')->setTimezone('UTC')
@@ -18,8 +19,12 @@ class NewYorkIncomeTest extends \TestCase
 
         NewYorkIncomeTaxInformation::forUser($this->user)
             ->update([
-                'exemptions' => $exemptions,
+                'ny_allowances' => $allowances,
+                'nyc_allowances' => 10, // should not be used
                 'filing_status' => $filing_status,
+                'ny_additional_withholding' => $additional_withholding,
+                'nyc_additional_withholding' => 10, // should not be used
+                'yonkers_additional_withholding' => 10, // should not be used
             ]);
 
         $results = $this->taxes->calculate(function ($taxes) use ($earnings) {
@@ -40,12 +45,14 @@ class NewYorkIncomeTest extends \TestCase
                 'January 1, 2019 8am',
                 NewYorkIncome::FILING_SINGLE,
                 0,
+                0,
                 145,
                 0.1,
             ],
             '1' => [
                 'January 1, 2019 8am',
                 NewYorkIncome::FILING_SINGLE,
+                0,
                 0,
                 300,
                 6.3,
@@ -54,6 +61,7 @@ class NewYorkIncomeTest extends \TestCase
                 'January 1, 2019 8am',
                 NewYorkIncome::FILING_SINGLE,
                 2,
+                0,
                 500,
                 14.6,
             ],
@@ -61,6 +69,7 @@ class NewYorkIncomeTest extends \TestCase
                 'January 1, 2019 8am',
                 NewYorkIncome::FILING_SINGLE,
                 3,
+                0,
                 700,
                 25.53,
             ],
@@ -68,6 +77,7 @@ class NewYorkIncomeTest extends \TestCase
                 'January 1, 2019 8am',
                 NewYorkIncome::FILING_SINGLE,
                 3,
+                0,
                 900,
                 37.95,
             ],
@@ -75,6 +85,7 @@ class NewYorkIncomeTest extends \TestCase
                 'January 1, 2019 8am',
                 NewYorkIncome::FILING_SINGLE,
                 2,
+                0,
                 1300,
                 63.98,
             ],
@@ -82,12 +93,14 @@ class NewYorkIncomeTest extends \TestCase
                 'January 1, 2019 8am',
                 NewYorkIncome::FILING_SINGLE,
                 11,
+                0,
                 1000,
                 34.6,
             ],
             '7' => [
                 'January 1, 2019 8am',
                 NewYorkIncome::FILING_MARRIED,
+                0,
                 0,
                 145,
                 null,
@@ -96,6 +109,7 @@ class NewYorkIncomeTest extends \TestCase
                 'January 1, 2019 8am',
                 NewYorkIncome::FILING_MARRIED,
                 0,
+                0,
                 300,
                 5.88,
             ],
@@ -103,6 +117,7 @@ class NewYorkIncomeTest extends \TestCase
                 'January 1, 2019 8am',
                 NewYorkIncome::FILING_MARRIED,
                 2,
+                0,
                 500,
                 13.97,
             ],
@@ -110,6 +125,7 @@ class NewYorkIncomeTest extends \TestCase
                 'January 1, 2019 8am',
                 NewYorkIncome::FILING_MARRIED,
                 3,
+                0,
                 700,
                 24.87,
             ],
@@ -117,6 +133,7 @@ class NewYorkIncomeTest extends \TestCase
                 'January 1, 2019 8am',
                 NewYorkIncome::FILING_MARRIED,
                 3,
+                0,
                 900,
                 37.29,
             ],
@@ -124,6 +141,7 @@ class NewYorkIncomeTest extends \TestCase
                 'January 1, 2019 8am',
                 NewYorkIncome::FILING_MARRIED,
                 2,
+                0,
                 2000,
                 107.51,
             ],
@@ -131,8 +149,17 @@ class NewYorkIncomeTest extends \TestCase
                 'January 1, 2019 8am',
                 NewYorkIncome::FILING_MARRIED,
                 11,
+                0,
                 1000,
                 33.95,
+            ],
+            '14' => [
+                'January 1, 2019 8am',
+                NewYorkIncome::FILING_MARRIED,
+                11,
+                10,
+                1000,
+                43.95,
             ],
         ];
     }

--- a/tests/Unit/Countries/US/NewYork/YonkersTest.php
+++ b/tests/Unit/Countries/US/NewYork/YonkersTest.php
@@ -3,7 +3,6 @@
 namespace Appleton\Taxes\Countries\US\NewYork\Yonkers;
 
 use Appleton\Taxes\Countries\US\NewYork\NewYorkIncome\NewYorkIncome;
-use Appleton\Taxes\Countries\US\NewYork\Yonkers\Yonkers;
 use Appleton\Taxes\Models\Countries\US\NewYork\NewYorkIncomeTaxInformation;
 use Carbon\Carbon;
 
@@ -12,7 +11,8 @@ class YonkersTest extends \TestCase
     /**
      * @dataProvider provideTestData
      */
-    public function testYonkers($date, $home_location, $work_location, $filing_status, $exemptions, $earnings, $result)
+    public function testYonkers($date, $home_location, $work_location, $filing_status, $allowances,
+                                $additional_withholding, $earnings, $result)
     {
         Carbon::setTestNow(
             Carbon::parse($date, 'America/Chicago')->setTimezone('UTC')
@@ -20,8 +20,12 @@ class YonkersTest extends \TestCase
 
         NewYorkIncomeTaxInformation::forUser($this->user)
             ->update([
-                'exemptions' => $exemptions,
+                'ny_allowances' => $allowances,
+                'nyc_allowances' => 10, // should not be used
                 'filing_status' => $filing_status,
+                'yonkers_additional_withholding' => $additional_withholding,
+                'ny_additional_withholding' => 10, // should not be used
+                'nyc_additional_withholding' => 10, // should not be used
             ]);
 
         $results = $this->taxes->calculate(function ($taxes) use ($home_location, $work_location, $earnings) {
@@ -44,6 +48,7 @@ class YonkersTest extends \TestCase
                 $this->getLocation('us.new_york.yonkers'),
                 NewYorkIncome::FILING_SINGLE,
                 4,
+                0,
                 1000,
                 7.20,
             ],
@@ -53,6 +58,7 @@ class YonkersTest extends \TestCase
                 $this->getLocation('us.new_york.yonkers'),
                 NewYorkIncome::FILING_SINGLE,
                 2,
+                0,
                 500,
                 2.45,
             ],
@@ -62,6 +68,7 @@ class YonkersTest extends \TestCase
                 $this->getLocation('us.new_york.yonkers'),
                 NewYorkIncome::FILING_SINGLE,
                 12,
+                0,
                 500,
                 0.85,
             ],
@@ -71,6 +78,7 @@ class YonkersTest extends \TestCase
                 $this->getLocation('us.new_york.yonkers'),
                 NewYorkIncome::FILING_MARRIED,
                 3,
+                0,
                 700,
                 4.17,
             ],
@@ -80,6 +88,7 @@ class YonkersTest extends \TestCase
                 $this->getLocation('us.new_york.yonkers'),
                 NewYorkIncome::FILING_MARRIED,
                 5,
+                0,
                 900,
                 5.85,
             ],
@@ -89,6 +98,7 @@ class YonkersTest extends \TestCase
                 $this->getLocation('us.new_york.yonkers'),
                 NewYorkIncome::FILING_MARRIED,
                 2,
+                0,
                 2000,
                 18.01,
             ],
@@ -98,6 +108,7 @@ class YonkersTest extends \TestCase
                 $this->getLocation('us.new_york.yonkers'),
                 NewYorkIncome::FILING_MARRIED,
                 11,
+                0,
                 1000,
                 5.69,
             ],
@@ -106,6 +117,7 @@ class YonkersTest extends \TestCase
                 $this->getLocation('us.alabama'),
                 $this->getLocation('us.new_york.yonkers'),
                 NewYorkIncome::FILING_SINGLE,
+                0,
                 0,
                 50,
                 null,
@@ -116,6 +128,7 @@ class YonkersTest extends \TestCase
                 $this->getLocation('us.new_york.yonkers'),
                 NewYorkIncome::FILING_SINGLE,
                 0,
+                0,
                 250,
                 1.06,
             ],
@@ -124,6 +137,7 @@ class YonkersTest extends \TestCase
                 $this->getLocation('us.alabama'),
                 $this->getLocation('us.new_york.yonkers'),
                 NewYorkIncome::FILING_SINGLE,
+                0,
                 0,
                 500,
                 2.40,
@@ -134,6 +148,7 @@ class YonkersTest extends \TestCase
                 $this->getLocation('us.new_york.yonkers'),
                 NewYorkIncome::FILING_SINGLE,
                 0,
+                0,
                 700,
                 3.50,
             ],
@@ -143,8 +158,19 @@ class YonkersTest extends \TestCase
                 $this->getLocation('us.new_york.yonkers'),
                 NewYorkIncome::FILING_SINGLE,
                 0,
+                0,
                 900,
                 4.50,
+            ],
+            '12' => [
+                'January 1, 2019 8am',
+                $this->getLocation('us.new_york.yonkers'),
+                $this->getLocation('us.new_york.yonkers'),
+                NewYorkIncome::FILING_MARRIED,
+                2,
+                5,
+                2000,
+                23.01,
             ],
         ];
     }


### PR DESCRIPTION
### Ticket
[Add additional columns in NY tax table - Include NYC and Yonkers Tax Options](https://spurjob.atlassian.net/browse/ACC-322)

### Changes
* Add nyc allowances and nyc/yonkers additional withholdings