### PR TITLE
ACC-330 Hotfix to fix Connecticut Filing Statuses

### DIFF
--- a/src/Countries/US/Connecticut/ConnecticutIncome/ConnecticutIncome.php
+++ b/src/Countries/US/Connecticut/ConnecticutIncome/ConnecticutIncome.php
@@ -15,6 +15,15 @@ abstract class ConnecticutIncome extends BaseStateIncome
     public const WITHHOLDING_CODE_E = 'E';
     public const WITHHOLDING_CODE_F = 'F';
 
+    const FILING_STATUSES = [
+        self::WITHHOLDING_CODE_A => 'A',
+        self::WITHHOLDING_CODE_B => 'B',
+        self::WITHHOLDING_CODE_C => 'C',
+        self::WITHHOLDING_CODE_D => 'D',
+        self::WITHHOLDING_CODE_E => 'E',
+        self::WITHHOLDING_CODE_F => 'F',
+    ];
+
     const PERSONAL_EXEMPTION = [
         self::WITHHOLDING_CODE_A => [
             'base' => 24000,


### PR DESCRIPTION
refs: https://spurjob.atlassian.net/browse/ACC-330

Tasie was getting an error about filing statuses during testing, since there is a `filing_status` the api is expecting an array of `filing_statuses`