### PR TITLE
Feature/acc 546 2020 changes

### DIFF
--- a/src/Countries/US/Arkansas/ArkansasUnemployment/V20200101/ArkansasUnemployment.php
+++ b/src/Countries/US/Arkansas/ArkansasUnemployment/V20200101/ArkansasUnemployment.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\Arkansas\ArkansasUnemployment\V20200101;
+
+use Appleton\Taxes\Classes\WorkerTaxes\Payroll;
+use Appleton\Taxes\Countries\US\Arkansas\ArkansasUnemployment\ArkansasUnemployment as BaseArkansasUnemployment;
+
+class ArkansasUnemployment extends BaseArkansasUnemployment
+{
+    public const NEW_EMPLOYER_RATE = 0.032;
+    public const WAGE_BASE = 7000;
+
+    public function __construct(Payroll $payroll)
+    {
+        parent::__construct($payroll);
+        $this->tax_rate = config('taxes.rates.us.arkansas.unemployment', static::NEW_EMPLOYER_RATE);
+    }
+}

--- a/src/Countries/US/Colorado/ColoradoUnemployment/V20200101/ColoradoUnemployment.php
+++ b/src/Countries/US/Colorado/ColoradoUnemployment/V20200101/ColoradoUnemployment.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\Colorado\ColoradoUnemployment\V20200101;
+
+use Appleton\Taxes\Classes\WorkerTaxes\Payroll;
+use Appleton\Taxes\Countries\US\Colorado\ColoradoUnemployment\ColoradoUnemployment as BaseColoradoUnemployment;
+
+class ColoradoUnemployment extends BaseColoradoUnemployment
+{
+    const FUTA_CREDIT = 0.054;
+
+    const NEW_EMPLOYER_RATE = 0.017;
+
+    const WAGE_BASE = 13600;
+
+    public function __construct(Payroll $payroll)
+    {
+        parent::__construct($payroll);
+        $this->tax_rate = config('taxes.rates.us.colorado.unemployment', static::NEW_EMPLOYER_RATE);
+    }
+}

--- a/src/Countries/US/Iowa/IowaUnemployment/V20200101/IowaUnemployment.php
+++ b/src/Countries/US/Iowa/IowaUnemployment/V20200101/IowaUnemployment.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\Iowa\IowaUnemployment\V20200101;
+
+use Appleton\Taxes\Classes\WorkerTaxes\Payroll;
+use Appleton\Taxes\Countries\US\Iowa\IowaUnemployment\IowaUnemployment as BaseIowaUnemployment;
+
+class IowaUnemployment extends BaseIowaUnemployment
+{
+    const FUTA_CREDIT = 0.054;
+    const NEW_EMPLOYER_RATE = 0.01;
+    const WAGE_BASE = 31600;
+
+    public function __construct(Payroll $payroll)
+    {
+        parent::__construct($payroll);
+        $this->tax_rate = config('taxes.rates.us.iowa.unemployment', static::NEW_EMPLOYER_RATE);
+    }
+}

--- a/src/Countries/US/Kentucky/KentuckyIncome/KentuckyIncome.php
+++ b/src/Countries/US/Kentucky/KentuckyIncome/KentuckyIncome.php
@@ -15,4 +15,19 @@ abstract class KentuckyIncome extends BaseStateIncome
         parent::__construct($payroll);
         $this->tax_information = $tax_information;
     }
+
+    abstract protected function getTaxRate(): float;
+
+    abstract protected function getStandardDeduction(): int;
+
+    public function getTaxBrackets(): array
+    {
+        return [[0, $this->getTaxRate(), 0]];
+    }
+
+    public function getAdjustedEarnings(): float
+    {
+        $gross_wages = $this->payroll->getEarnings() * $this->payroll->pay_periods;
+        return $gross_wages - $this->getStandardDeduction();
+    }
 }

--- a/src/Countries/US/Kentucky/KentuckyIncome/V20200101/KentuckyIncome.php
+++ b/src/Countries/US/Kentucky/KentuckyIncome/V20200101/KentuckyIncome.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Appleton\Taxes\Countries\US\Kentucky\KentuckyIncome\V20190101;
+namespace Appleton\Taxes\Countries\US\Kentucky\KentuckyIncome\V20200101;
 
 use Appleton\Taxes\Countries\US\Kentucky\KentuckyIncome\KentuckyIncome as BaseKentuckyIncome;
 
@@ -9,7 +9,7 @@ class KentuckyIncome extends BaseKentuckyIncome
     public const SUPPLEMENTAL_TAX_RATE = 0;
 
     public const TAX_RATE = 0.05;
-    private const STANDARD_DEDUCTION = 2590;
+    private const STANDARD_DEDUCTION = 2650;
 
     protected function getTaxRate(): float
     {

--- a/src/Countries/US/Kentucky/KentuckyUnemployment/V20200101/KentuckyUnemployment.php
+++ b/src/Countries/US/Kentucky/KentuckyUnemployment/V20200101/KentuckyUnemployment.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\Kentucky\KentuckyUnemployment\V20200101;
+
+use Appleton\Taxes\Classes\WorkerTaxes\Payroll;
+use Appleton\Taxes\Countries\US\Kentucky\KentuckyUnemployment\KentuckyUnemployment as BaseKentuckyUnemployment;
+
+class KentuckyUnemployment extends BaseKentuckyUnemployment
+{
+    public const FUTA_CREDIT = 0.054;
+    public const WAGE_BASE = 10800;
+
+    private const NEW_EMPLOYER_RATE = 0.027;
+
+    public function __construct(Payroll $payroll)
+    {
+        parent::__construct($payroll);
+        $this->tax_rate = config('taxes.rates.us.kentucky.unemployment', static::NEW_EMPLOYER_RATE);
+    }
+}

--- a/src/Countries/US/Missouri/MissouriUnemployment/V20200101/MissouriUnemployment.php
+++ b/src/Countries/US/Missouri/MissouriUnemployment/V20200101/MissouriUnemployment.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\Missouri\MissouriUnemployment\V20200101;
+
+use Appleton\Taxes\Classes\WorkerTaxes\Payroll;
+use Appleton\Taxes\Countries\US\Missouri\MissouriUnemployment\MissouriUnemployment as BaseMissouriUnemployment;
+
+class MissouriUnemployment extends BaseMissouriUnemployment
+{
+    const FUTA_CREDIT = 0.054;
+    const NEW_EMPLOYER_RATE = 0.027;
+    const WAGE_BASE = 11500;
+
+
+    public function __construct(Payroll $payroll)
+    {
+        parent::__construct($payroll);
+        $this->tax_rate = config('taxes.rates.us.missouri.unemployment', static::NEW_EMPLOYER_RATE);
+    }
+}

--- a/src/Countries/US/Nevada/NevadaUnemployment/V20200101/NevadaUnemployment.php
+++ b/src/Countries/US/Nevada/NevadaUnemployment/V20200101/NevadaUnemployment.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\Nevada\NevadaUnemployment\V20200101;
+
+use Appleton\Taxes\Classes\WorkerTaxes\Payroll;
+use Appleton\Taxes\Countries\US\Nevada\NevadaUnemployment\NevadaUnemployment as BaseNevadaUnemployment;
+
+class NevadaUnemployment extends BaseNevadaUnemployment
+{
+    public const FUTA_CREDIT = 0.054;
+    public const TAX_RATE = 0.03;
+    public const WAGE_BASE = 32500;
+
+    public function __construct(Payroll $payroll)
+    {
+        parent::__construct($payroll);
+        $this->tax_rate = config('taxes.rates.us.nevada.unemployment', static::TAX_RATE);
+    }
+}

--- a/src/Countries/US/NewJersey/NewJerseyUnemployment/V20200101/NewJerseyUnemployment.php
+++ b/src/Countries/US/NewJersey/NewJerseyUnemployment/V20200101/NewJerseyUnemployment.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\NewJersey\NewJerseyUnemployment\V20200101;
+
+use Appleton\Taxes\Classes\WorkerTaxes\Payroll;
+use Appleton\Taxes\Countries\US\NewJersey\NewJerseyUnemployment\NewJerseyUnemployment as BaseNewJerseyUnemployment;
+
+class NewJerseyUnemployment extends BaseNewJerseyUnemployment
+{
+    const FUTA_CREDIT = 0.054;
+
+    const NEW_EMPLOYER_RATE = 0.028;
+
+    const WAGE_BASE = 35300;
+
+    public function __construct(Payroll $payroll)
+    {
+        parent::__construct($payroll);
+        $this->tax_rate = config('taxes.rates.us.new_jersey.unemployment', static::NEW_EMPLOYER_RATE);
+    }
+}

--- a/src/Countries/US/NewMexico/NewMexicoUnemployment/V20200101/NewMexicoUnemployment.php
+++ b/src/Countries/US/NewMexico/NewMexicoUnemployment/V20200101/NewMexicoUnemployment.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\NewMexico\NewMexicoUnemployment\V20200101;
+
+use Appleton\Taxes\Classes\WorkerTaxes\Payroll;
+use Appleton\Taxes\Countries\US\NewMexico\NewMexicoUnemployment\NewMexicoUnemployment as BaseNewMexicoUnemployment;
+
+class NewMexicoUnemployment extends BaseNewMexicoUnemployment
+{
+    public const FUTA_CREDIT = 0.054;
+
+    public const NEW_EMPLOYER_RATE = 0.01;
+
+    public const WAGE_BASE = 25800;
+
+    public function __construct(Payroll $payroll)
+    {
+        parent::__construct($payroll);
+        $this->tax_rate = config('taxes.rates.us.new_mexico.unemployment', static::NEW_EMPLOYER_RATE);
+    }
+}

--- a/src/Countries/US/NewYork/NewYorkUnemployment/V20200101/NewYorkUnemployment.php
+++ b/src/Countries/US/NewYork/NewYorkUnemployment/V20200101/NewYorkUnemployment.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\NewYork\NewYorkUnemployment\V20200101;
+
+use Appleton\Taxes\Classes\WorkerTaxes\Payroll;
+use Appleton\Taxes\Countries\US\NewYork\NewYorkUnemployment\NewYorkUnemployment as BaseNewYorkUnemployment;
+
+class NewYorkUnemployment extends BaseNewYorkUnemployment
+{
+    const FUTA_CREDIT = 0.054;
+
+    const NEW_EMPLOYER_RATE = 0.036;
+
+    const WAGE_BASE = 11600;
+
+    public function __construct(Payroll $payroll)
+    {
+        parent::__construct($payroll);
+        $this->tax_rate = config('taxes.rates.us.new_york.unemployment', static::NEW_EMPLOYER_RATE);
+    }
+}

--- a/src/Countries/US/NorthCarolina/NorthCarolinaIncome/NorthCarolinaIncome.php
+++ b/src/Countries/US/NorthCarolina/NorthCarolinaIncome/NorthCarolinaIncome.php
@@ -2,7 +2,10 @@
 
 namespace Appleton\Taxes\Countries\US\NorthCarolina\NorthCarolinaIncome;
 
+use Appleton\Taxes\Classes\WorkerTaxes\Payroll;
 use Appleton\Taxes\Classes\WorkerTaxes\Taxes\BaseStateIncome;
+use Appleton\Taxes\Models\Countries\US\NorthCarolina\NorthCarolinaIncomeTaxInformation;
+use Illuminate\Database\Eloquent\Collection;
 
 abstract class NorthCarolinaIncome extends BaseStateIncome
 {
@@ -17,4 +20,70 @@ abstract class NorthCarolinaIncome extends BaseStateIncome
         self::FILING_MARRIED => 'FILING_MARRIED',
         self::FILING_SEPERATE => 'FILING_SEPERATE',
     ];
+
+    public function __construct(NorthCarolinaIncomeTaxInformation $tax_information, Payroll $payroll)
+    {
+        parent::__construct($payroll);
+        $this->tax_information = $tax_information;
+    }
+
+    abstract public function getSupplementalTaxRate();
+
+    abstract public function getTaxRate();
+
+    abstract public function getStandardDeductions();
+
+    abstract public function getDependentExemptionBrackets();
+
+    public function compute(Collection $tax_areas)
+    {
+        if ($this->isUserClaimingExemption()) {
+            return 0.00;
+        }
+
+        $tax_amount = $this->getTaxAmountFromTaxBrackets($this->getAdjustedEarnings(), $this->getTaxBrackets())
+            / $this->payroll->pay_periods;
+        $this->tax_total = $this->payroll->withholdTax(round($tax_amount)) +
+            $this->payroll->withholdTax($this->getSupplementalIncomeTax()) +
+            $this->payroll->withholdTax($this->getAdditionalWithholding());
+
+        return round(((int)($this->tax_total * 100)) / 100, 2);
+    }
+
+    public function getAdjustedEarnings()
+    {
+        return $this->getGrossEarnings() - $this->getStandardDeduction() - $this->getDependentExemption();
+    }
+
+    public function getSupplementalIncomeTax()
+    {
+        return $this->payroll->getSupplementalEarnings() * $this->getSupplementalTaxRate();
+    }
+
+    public function getTaxBrackets()
+    {
+        return [[0, $this->getTaxRate(), 0]];
+    }
+
+    private function getStandardDeduction()
+    {
+        $standard_deductions = $this->getStandardDeductions();
+        if (array_key_exists($this->tax_information->filing_status, $standard_deductions)) {
+            return $standard_deductions[$this->tax_information->filing_status];
+        }
+
+        return 0;
+    }
+
+    private function getDependentExemption()
+    {
+        $gross_earnings = $this->getGrossEarnings();
+        $dependent_exemption = $this->getTaxBracket($gross_earnings, $this->getDependentExemptionBrackets()[$this->tax_information->filing_status]);
+        return $this->tax_information->dependents * $dependent_exemption[1];
+    }
+
+    private function getGrossEarnings()
+    {
+        return ($this->payroll->getEarnings() - $this->payroll->getSupplementalEarnings()) * $this->payroll->pay_periods;
+    }
 }

--- a/src/Countries/US/NorthCarolina/NorthCarolinaIncome/NorthCarolinaIncome.php
+++ b/src/Countries/US/NorthCarolina/NorthCarolinaIncome/NorthCarolinaIncome.php
@@ -27,13 +27,13 @@ abstract class NorthCarolinaIncome extends BaseStateIncome
         $this->tax_information = $tax_information;
     }
 
-    abstract public function getSupplementalTaxRate();
+    abstract public function getSupplementalTaxRate(): float;
 
-    abstract public function getTaxRate();
+    abstract public function getTaxRate(): float;
 
-    abstract public function getStandardDeductions();
+    abstract public function getStandardDeductions(): array;
 
-    abstract public function getDependentExemptionBrackets();
+    abstract public function getDependentExemptionBrackets(): array;
 
     public function compute(Collection $tax_areas)
     {

--- a/src/Countries/US/NorthCarolina/NorthCarolinaIncome/V20180101/NorthCarolinaIncome.php
+++ b/src/Countries/US/NorthCarolina/NorthCarolinaIncome/V20180101/NorthCarolinaIncome.php
@@ -8,18 +8,18 @@ use Appleton\Taxes\Models\Countries\US\NorthCarolina\NorthCarolinaIncomeTaxInfor
 
 class NorthCarolinaIncome extends BaseNorthCarolinaIncome
 {
-    const SUPPLEMENTAL_TAX_RATE = 0.05599;
+    public const TAX_RATE = 0.05499;
 
-    const TAX_RATE = 0.05499;
+    private const SUPPLEMENTAL_TAX_RATE = 0.05599;
 
-    const STANDARD_DEDUCTIONS = [
+    private const STANDARD_DEDUCTIONS = [
         self::FILING_SINGLE => 8750,
         self::FILING_HEAD_OF_HOUSEHOLD => 14000,
         self::FILING_MARRIED => 17500,
         self::FILING_SEPERATE => 8750,
     ];
 
-    const DEPENDENT_EXEMPTION_BRACKETS = [
+    private const DEPENDENT_EXEMPTION_BRACKETS = [
         self::FILING_SINGLE => [
             [0, 2500],
             [20000, 2000],
@@ -54,47 +54,23 @@ class NorthCarolinaIncome extends BaseNorthCarolinaIncome
         ],
     ];
 
-    public function __construct(NorthCarolinaIncomeTaxInformation $tax_information, Payroll $payroll)
+    public function getSupplementalTaxRate(): float
     {
-        parent::__construct($payroll);
-        $this->tax_information = $tax_information;
+        return self::SUPPLEMENTAL_TAX_RATE;
     }
 
-    public function getAdjustedEarnings()
+    public function getTaxRate(): float
     {
-        return $this->getGrossEarnings() - $this->getStandardDeduction() - $this->getDependentExemption();
+        return self::TAX_RATE;
     }
 
-    public function getSupplementalIncomeTax()
+    public function getStandardDeductions(): array
     {
-        $annual_income = $this->getGrossEarnings();
-
-        return $this->payroll->getSupplementalEarnings() * self::SUPPLEMENTAL_TAX_RATE;
+        return self::STANDARD_DEDUCTIONS;
     }
 
-    public function getTaxBrackets()
+    public function getDependentExemptionBrackets(): array
     {
-        return [[0, self::TAX_RATE, 0]];
-    }
-
-    private function getStandardDeduction()
-    {
-        if (array_key_exists($this->tax_information->filing_status, static::STANDARD_DEDUCTIONS)) {
-            return static::STANDARD_DEDUCTIONS[$this->tax_information->filing_status];
-        }
-
-        return 0;
-    }
-
-    private function getDependentExemption()
-    {
-        $gross_earnings = $this->getGrossEarnings();
-        $dependent_exemption = $this->getTaxBracket($gross_earnings, static::DEPENDENT_EXEMPTION_BRACKETS[$this->tax_information->filing_status]);
-        return $this->tax_information->dependents * $dependent_exemption[1];
-    }
-
-    private function getGrossEarnings()
-    {
-        return ($this->payroll->getEarnings() - $this->payroll->getSupplementalEarnings()) * $this->payroll->pay_periods;
+        return self::DEPENDENT_EXEMPTION_BRACKETS;
     }
 }

--- a/src/Countries/US/NorthCarolina/NorthCarolinaIncome/V20200101/NorthCarolinaIncome.php
+++ b/src/Countries/US/NorthCarolina/NorthCarolinaIncome/V20200101/NorthCarolinaIncome.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Appleton\Taxes\Countries\US\NorthCarolina\NorthCarolinaIncome\V20190101;
+namespace Appleton\Taxes\Countries\US\NorthCarolina\NorthCarolinaIncome\V20200101;
 
 use Appleton\Taxes\Countries\US\NorthCarolina\NorthCarolinaIncome\NorthCarolinaIncome as BaseNorthCarolinaIncome;
 
@@ -11,10 +11,10 @@ class NorthCarolinaIncome extends BaseNorthCarolinaIncome
     private const SUPPLEMENTAL_TAX_RATE = 0.0535;
 
     private const STANDARD_DEDUCTIONS = [
-        self::FILING_SINGLE => 10000,
-        self::FILING_HEAD_OF_HOUSEHOLD => 15000,
-        self::FILING_MARRIED => 10000,
-        self::FILING_SEPERATE => 10000,
+        self::FILING_SINGLE => 10750,
+        self::FILING_HEAD_OF_HOUSEHOLD => 16125,
+        self::FILING_MARRIED => 21500,
+        self::FILING_SEPERATE => 10750,
     ];
 
     private const DEPENDENT_EXEMPTION_BRACKETS = [

--- a/src/Countries/US/NorthCarolina/NorthCarolinaUnemployment/V20200101/NorthCarolinaUnemployment.php
+++ b/src/Countries/US/NorthCarolina/NorthCarolinaUnemployment/V20200101/NorthCarolinaUnemployment.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\NorthCarolina\NorthCarolinaUnemployment\V20200101;
+
+use Appleton\Taxes\Classes\WorkerTaxes\Payroll;
+use Appleton\Taxes\Countries\US\NorthCarolina\NorthCarolinaUnemployment\NorthCarolinaUnemployment as BaseNorthCarolinaUnemployment;
+
+class NorthCarolinaUnemployment extends BaseNorthCarolinaUnemployment
+{
+    const FUTA_CREDIT = 0.054;
+
+    const NEW_EMPLOYER_RATE = 0.01;
+
+    const WAGE_BASE = 25200;
+
+    public function __construct(Payroll $payroll)
+    {
+        parent::__construct($payroll);
+        $this->tax_rate = config('taxes.rates.us.north_carolina.unemployment', static::NEW_EMPLOYER_RATE);
+    }
+}

--- a/src/Countries/US/Ohio/OhioUnemployment/V20200101/OhioUnemployment.php
+++ b/src/Countries/US/Ohio/OhioUnemployment/V20200101/OhioUnemployment.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\Ohio\OhioUnemployment\V20200101;
+
+use Appleton\Taxes\Classes\WorkerTaxes\Payroll;
+use Appleton\Taxes\Countries\US\Ohio\OhioUnemployment\OhioUnemployment as BaseOhioUnemployment;
+
+class OhioUnemployment extends BaseOhioUnemployment
+{
+    const FUTA_CREDIT = 0.054;
+
+    const NEW_EMPLOYER_RATE = 0.027;
+
+    const WAGE_BASE = 9000;
+
+    public function __construct(Payroll $payroll)
+    {
+        parent::__construct($payroll);
+        $this->tax_rate = config('taxes.rates.us.ohio.unemployment', static::NEW_EMPLOYER_RATE);
+    }
+}

--- a/src/Countries/US/Oklahoma/OklahomaUnemployment/V20200101/OklahomaUnemployment.php
+++ b/src/Countries/US/Oklahoma/OklahomaUnemployment/V20200101/OklahomaUnemployment.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\Oklahoma\OklahomaUnemployment\V20200101;
+
+use Appleton\Taxes\Classes\WorkerTaxes\Payroll;
+use Appleton\Taxes\Countries\US\Oklahoma\OklahomaUnemployment\OklahomaUnemployment as BaseOklahomaUnemployment;
+
+class OklahomaUnemployment extends BaseOklahomaUnemployment
+{
+    const FUTA_CREDIT = 0.054;
+
+    const NEW_EMPLOYER_RATE = 0.015;
+
+    const WAGE_BASE = 18700;
+
+    public function __construct(Payroll $payroll)
+    {
+        parent::__construct($payroll);
+        $this->tax_rate = config('taxes.rates.us.oklahoma.unemployment', static::NEW_EMPLOYER_RATE);
+    }
+}

--- a/src/Countries/US/Oregon/OregonUnemployment/V20190101/OregonUnemployment.php
+++ b/src/Countries/US/Oregon/OregonUnemployment/V20190101/OregonUnemployment.php
@@ -14,6 +14,6 @@ class OregonUnemployment extends BaseOregonUnemployment
     public function __construct(Payroll $payroll)
     {
         parent::__construct($payroll);
-        $this->tax_rate = config('taxes.rates.us.oregon.unemployment', static::NEW_EMPLOYER_RATE);
+        $this->tax_rate = static::NEW_EMPLOYER_RATE;
     }
 }

--- a/src/Countries/US/Oregon/OregonUnemployment/V20200101/OregonUnemployment.php
+++ b/src/Countries/US/Oregon/OregonUnemployment/V20200101/OregonUnemployment.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\Oregon\OregonUnemployment\V20200101;
+
+use Appleton\Taxes\Classes\WorkerTaxes\Payroll;
+use Appleton\Taxes\Countries\US\Oregon\OregonUnemployment\OregonUnemployment as BaseOregonUnemployment;
+
+class OregonUnemployment extends BaseOregonUnemployment
+{
+    const FUTA_CREDIT = 0.054;
+    const NEW_EMPLOYER_RATE = 0.024;
+    const WAGE_BASE = 42100;
+
+    public function __construct(Payroll $payroll)
+    {
+        parent::__construct($payroll);
+        $this->tax_rate = config('taxes.rates.us.oregon.unemployment', static::NEW_EMPLOYER_RATE);
+    }
+}

--- a/src/Countries/US/Oregon/OregonUnemployment/V20200101/OregonUnemployment.php
+++ b/src/Countries/US/Oregon/OregonUnemployment/V20200101/OregonUnemployment.php
@@ -8,7 +8,7 @@ use Appleton\Taxes\Countries\US\Oregon\OregonUnemployment\OregonUnemployment as 
 class OregonUnemployment extends BaseOregonUnemployment
 {
     const FUTA_CREDIT = 0.054;
-    const NEW_EMPLOYER_RATE = 0.024;
+    const NEW_EMPLOYER_RATE = 0.021;
     const WAGE_BASE = 42100;
 
     public function __construct(Payroll $payroll)

--- a/src/Countries/US/SocialSecurity/SocialSecurity.php
+++ b/src/Countries/US/SocialSecurity/SocialSecurity.php
@@ -3,10 +3,27 @@
 namespace Appleton\Taxes\Countries\US\SocialSecurity;
 
 use Appleton\Taxes\Classes\WorkerTaxes\Taxes\BaseTax;
+use Appleton\Taxes\Traits\HasWageBase;
+use Illuminate\Database\Eloquent\Collection;
 
 abstract class SocialSecurity extends BaseTax
 {
-    const TYPE = 'federal';
-    const WITHHELD = true;
-    const PRIORITY = 0;
+    use HasWageBase;
+
+    public const TYPE = 'federal';
+    public const WITHHELD = true;
+    public const PRIORITY = 0;
+
+    abstract protected function getTaxRate(): float;
+
+    public function getAdjustedEarnings()
+    {
+        return min($this->payroll->getEarnings(), $this->getBaseEarnings());
+    }
+
+    public function compute(Collection $tax_areas)
+    {
+        $this->tax_total = $this->payroll->withholdTax($this->getAdjustedEarnings() * $this->getTaxRate());
+        return round($this->tax_total, 2);
+    }
 }

--- a/src/Countries/US/SocialSecurity/SocialSecurityEmployer.php
+++ b/src/Countries/US/SocialSecurity/SocialSecurityEmployer.php
@@ -2,7 +2,27 @@
 
 namespace Appleton\Taxes\Countries\US\SocialSecurity;
 
-abstract class SocialSecurityEmployer extends SocialSecurity
+use Appleton\Taxes\Classes\WorkerTaxes\Taxes\BaseTax;
+use Appleton\Taxes\Traits\HasWageBase;
+use Illuminate\Database\Eloquent\Collection;
+
+abstract class SocialSecurityEmployer extends BaseTax
 {
-    const WITHHELD = false;
+    use HasWageBase;
+
+    public const TYPE = 'federal';
+    public const WITHHELD = false;
+    public const PRIORITY = 0;
+
+    abstract protected function getTaxRate(): float;
+
+    public function getAdjustedEarnings()
+    {
+        return min($this->payroll->getEarnings(), $this->getBaseEarnings());
+    }
+
+    public function compute(Collection $tax_areas)
+    {
+        return round($this->getAdjustedEarnings() * $this->getTaxRate(), 2);
+    }
 }

--- a/src/Countries/US/SocialSecurity/V20170101/SocialSecurityEmployer.php
+++ b/src/Countries/US/SocialSecurity/V20170101/SocialSecurityEmployer.php
@@ -2,14 +2,15 @@
 
 namespace Appleton\Taxes\Countries\US\SocialSecurity\V20170101;
 
-use Illuminate\Database\Eloquent\Collection;
+use Appleton\Taxes\Countries\US\SocialSecurity\SocialSecurityEmployer as BaseSocialSecurityEmployer;
 
-class SocialSecurityEmployer extends SocialSecurity
+class SocialSecurityEmployer extends BaseSocialSecurityEmployer
 {
-    const WITHHELD = false;
+    public const TAX_RATE = SocialSecurity::TAX_RATE;
+    public const WAGE_BASE = SocialSecurity::WAGE_BASE;
 
-    public function compute(Collection $tax_areas)
+    protected function getTaxRate(): float
     {
-        return round($this->getAdjustedEarnings() * static::TAX_RATE, 2);
+        return self::TAX_RATE;
     }
 }

--- a/src/Countries/US/SocialSecurity/V20180101/SocialSecurity.php
+++ b/src/Countries/US/SocialSecurity/V20180101/SocialSecurity.php
@@ -3,24 +3,14 @@
 namespace Appleton\Taxes\Countries\US\SocialSecurity\V20180101;
 
 use Appleton\Taxes\Countries\US\SocialSecurity\SocialSecurity as BaseSocialSecurity;
-use Appleton\Taxes\Traits\HasWageBase;
-use Illuminate\Database\Eloquent\Collection;
 
 class SocialSecurity extends BaseSocialSecurity
 {
-    use HasWageBase;
+    public const TAX_RATE = 0.062;
+    public const WAGE_BASE = 128400;
 
-    const TAX_RATE = 0.062;
-    const WAGE_BASE = 128400;
-
-    public function getAdjustedEarnings()
+    protected function getTaxRate(): float
     {
-        return min($this->payroll->getEarnings(), $this->getBaseEarnings());
-    }
-
-    public function compute(Collection $tax_areas)
-    {
-        $this->tax_total = $this->payroll->withholdTax($this->getAdjustedEarnings() * static::TAX_RATE);
-        return round($this->tax_total, 2);
+        return self::TAX_RATE;
     }
 }

--- a/src/Countries/US/SocialSecurity/V20190101/SocialSecurity.php
+++ b/src/Countries/US/SocialSecurity/V20190101/SocialSecurity.php
@@ -3,24 +3,14 @@
 namespace Appleton\Taxes\Countries\US\SocialSecurity\V20190101;
 
 use Appleton\Taxes\Countries\US\SocialSecurity\SocialSecurity as BaseSocialSecurity;
-use Appleton\Taxes\Traits\HasWageBase;
-use Illuminate\Database\Eloquent\Collection;
 
 class SocialSecurity extends BaseSocialSecurity
 {
-    use HasWageBase;
+    public const TAX_RATE = 0.062;
+    public const WAGE_BASE = 132900;
 
-    const TAX_RATE = 0.062;
-    const WAGE_BASE = 132900;
-
-    public function getAdjustedEarnings()
+    protected function getTaxRate(): float
     {
-        return min($this->payroll->getEarnings(), $this->getBaseEarnings());
-    }
-
-    public function compute(Collection $tax_areas)
-    {
-        $this->tax_total = $this->payroll->withholdTax($this->getAdjustedEarnings() * static::TAX_RATE);
-        return round($this->tax_total, 2);
+        return self::TAX_RATE;
     }
 }

--- a/src/Countries/US/SocialSecurity/V20190101/SocialSecurityEmployer.php
+++ b/src/Countries/US/SocialSecurity/V20190101/SocialSecurityEmployer.php
@@ -2,14 +2,15 @@
 
 namespace Appleton\Taxes\Countries\US\SocialSecurity\V20190101;
 
-use Illuminate\Database\Eloquent\Collection;
+use Appleton\Taxes\Countries\US\SocialSecurity\SocialSecurityEmployer as BaseSocialSecurityEmployer;
 
-class SocialSecurityEmployer extends SocialSecurity
+class SocialSecurityEmployer extends BaseSocialSecurityEmployer
 {
-    const WITHHELD = false;
+    public const TAX_RATE = SocialSecurity::TAX_RATE;
+    public const WAGE_BASE = SocialSecurity::WAGE_BASE;
 
-    public function compute(Collection $tax_areas)
+    protected function getTaxRate(): float
     {
-        return round($this->getAdjustedEarnings() * static::TAX_RATE, 2);
+        return self::TAX_RATE;
     }
 }

--- a/src/Countries/US/SocialSecurity/V20200101/SocialSecurity.php
+++ b/src/Countries/US/SocialSecurity/V20200101/SocialSecurity.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Appleton\Taxes\Countries\US\SocialSecurity\V20170101;
+namespace Appleton\Taxes\Countries\US\SocialSecurity\V20200101;
 
 use Appleton\Taxes\Countries\US\SocialSecurity\SocialSecurity as BaseSocialSecurity;
 
 class SocialSecurity extends BaseSocialSecurity
 {
     public const TAX_RATE = 0.062;
-    public const WAGE_BASE = 127200;
+    public const WAGE_BASE = 137700;
 
     protected function getTaxRate(): float
     {

--- a/src/Countries/US/SocialSecurity/V20200101/SocialSecurityEmployer.php
+++ b/src/Countries/US/SocialSecurity/V20200101/SocialSecurityEmployer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Appleton\Taxes\Countries\US\SocialSecurity\V20180101;
+namespace Appleton\Taxes\Countries\US\SocialSecurity\V20200101;
 
 use Appleton\Taxes\Countries\US\SocialSecurity\SocialSecurityEmployer as BaseSocialSecurityEmployer;
 

--- a/src/Countries/US/Vermont/VermontUnemployment/V20200101/VermontUnemployment.php
+++ b/src/Countries/US/Vermont/VermontUnemployment/V20200101/VermontUnemployment.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\Vermont\VermontUnemployment\V20200101;
+
+use Appleton\Taxes\Classes\WorkerTaxes\Payroll;
+use Appleton\Taxes\Countries\US\Vermont\VermontUnemployment\VermontUnemployment as BaseVermontUnemployment;
+
+class VermontUnemployment extends BaseVermontUnemployment
+{
+    public const NEW_EMPLOYER_RATE = 0.01;
+    public const WAGE_BASE = 16100;
+
+    public function __construct(Payroll $payroll)
+    {
+        parent::__construct($payroll);
+        $this->tax_rate = config('taxes.rates.us.vermont.unemployment', static::NEW_EMPLOYER_RATE);
+    }
+}

--- a/src/Countries/US/Wyoming/WyomingUnemployment/V20200101/WyomingUnemployment.php
+++ b/src/Countries/US/Wyoming/WyomingUnemployment/V20200101/WyomingUnemployment.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Appleton\Taxes\Countries\US\Wyoming\WyomingUnemployment\V20200101;
+
+use Appleton\Taxes\Classes\WorkerTaxes\Payroll;
+use Appleton\Taxes\Countries\US\Wyoming\WyomingUnemployment\WyomingUnemployment as BaseWyomingUnemployment;
+
+class WyomingUnemployment extends BaseWyomingUnemployment
+{
+    const FUTA_CREDIT = 0.054;
+    const NEW_EMPLOYER_RATE = .0122;
+    const WAGE_BASE = 26400;
+
+    public function __construct(Payroll $payroll)
+    {
+        parent::__construct($payroll);
+        $this->tax_rate = config('taxes.rates.us.wyoming.unemployment', static::NEW_EMPLOYER_RATE);
+    }
+}

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -297,7 +297,7 @@ return [
             ],
 
             'oregon' => [
-                'unemployment' => env('TAXES_OREGON_UNEMPLOYMENT_TAX_RATE', 0.024),
+                'unemployment' => env('TAXES_OREGON_UNEMPLOYMENT_TAX_RATE', 0.021),
             ],
 
             'pennsylvania' => [

--- a/tests/Unit/Countries/US/Arkansas/V20200101/ArkansasUnemploymentTest.php
+++ b/tests/Unit/Countries/US/Arkansas/V20200101/ArkansasUnemploymentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Appleton\Taxes\Tests\Unit\Countries\US\Arkansas\V20200101;
+
+use Appleton\Taxes\Countries\US\Arkansas\ArkansasUnemployment\ArkansasUnemployment;
+use Appleton\Taxes\Tests\Unit\Countries\UnemploymentTaxTestCase;
+use Appleton\Taxes\Tests\Unit\Countries\TestParameters;
+
+class ArkansasUnemploymentTest extends UnemploymentTaxTestCase
+{
+    private const DATE = '2020-01-01';
+    private const LOCATION = 'us.arkansas';
+    private const TAX_CLASS = ArkansasUnemployment::class;
+    private const TAX_RATE = 0.032;
+    private const WAGE_BASE = 700000;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->query_runner->addTax(self::TAX_CLASS);
+    }
+
+    /**
+     * @dataProvider provideData
+     */
+    public function testWageBase(TestParameters $parameters): void
+    {
+        $this->validateWageBase($parameters);
+    }
+
+    public function testWorkDifferentState(): void
+    {
+        $this->validateWorkDifferentState(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::TAX_RATE
+        );
+    }
+
+    public function testTaxRate(): void
+    {
+        $this->validateTaxRate(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            0.0321
+        );
+    }
+
+    public function provideData(): array
+    {
+        return $this->wageBaseBoundariesTestCases(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::WAGE_BASE,
+            self::TAX_RATE);
+    }
+}

--- a/tests/Unit/Countries/US/Colorado/V20200101/ColoradoUnemploymentTest.php
+++ b/tests/Unit/Countries/US/Colorado/V20200101/ColoradoUnemploymentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Appleton\Taxes\Tests\Unit\Countries\US\Colorado\V20200101;
+
+use Appleton\Taxes\Countries\US\Colorado\ColoradoUnemployment\ColoradoUnemployment;
+use Appleton\Taxes\Tests\Unit\Countries\UnemploymentTaxTestCase;
+use Appleton\Taxes\Tests\Unit\Countries\TestParameters;
+
+class ColoradoUnemploymentTest extends UnemploymentTaxTestCase
+{
+    private const DATE = '2020-01-01';
+    private const LOCATION = 'us.colorado';
+    private const TAX_CLASS = ColoradoUnemployment::class;
+    private const TAX_RATE = 0.017;
+    private const WAGE_BASE = 1360000;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->query_runner->addTax(self::TAX_CLASS);
+    }
+
+    /**
+     * @dataProvider provideData
+     */
+    public function testWageBase(TestParameters $parameters): void
+    {
+        $this->validateWageBase($parameters);
+    }
+
+    public function testWorkDifferentState(): void
+    {
+        $this->validateWorkDifferentState(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::TAX_RATE
+        );
+    }
+
+    public function testTaxRate(): void
+    {
+        $this->validateTaxRate(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            0.0321
+        );
+    }
+
+    public function provideData(): array
+    {
+        return $this->wageBaseBoundariesTestCases(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::WAGE_BASE,
+            self::TAX_RATE);
+    }
+}

--- a/tests/Unit/Countries/US/Iowa/V20200101/IowaUnemploymentTest.php
+++ b/tests/Unit/Countries/US/Iowa/V20200101/IowaUnemploymentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Appleton\Taxes\Tests\Unit\Countries\US\Iowa\V20200101;
+
+use Appleton\Taxes\Countries\US\Iowa\IowaUnemployment\IowaUnemployment;
+use Appleton\Taxes\Tests\Unit\Countries\UnemploymentTaxTestCase;
+use Appleton\Taxes\Tests\Unit\Countries\TestParameters;
+
+class IowaUnemploymentTest extends UnemploymentTaxTestCase
+{
+    private const DATE = '2020-01-01';
+    private const LOCATION = 'us.iowa';
+    private const TAX_CLASS = IowaUnemployment::class;
+    private const TAX_RATE = 0.01;
+    private const WAGE_BASE = 3160000;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->query_runner->addTax(self::TAX_CLASS);
+    }
+
+    /**
+     * @dataProvider provideData
+     */
+    public function testWageBase(TestParameters $parameters): void
+    {
+        $this->validateWageBase($parameters);
+    }
+
+    public function testWorkDifferentState(): void
+    {
+        $this->validateWorkDifferentState(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::TAX_RATE
+        );
+    }
+
+    public function testTaxRate(): void
+    {
+        $this->validateTaxRate(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            0.0321
+        );
+    }
+
+    public function provideData(): array
+    {
+        return $this->wageBaseBoundariesTestCases(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::WAGE_BASE,
+            self::TAX_RATE);
+    }
+}

--- a/tests/Unit/Countries/US/Kentucky/V20200101/KentuckyIncomeTest.php
+++ b/tests/Unit/Countries/US/Kentucky/V20200101/KentuckyIncomeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Appleton\Taxes\Tests\Unit\Countries\US\Kentucky\V20190101;
+namespace Appleton\Taxes\Tests\Unit\Countries\US\Kentucky\V20200101;
 
 use Appleton\Taxes\Countries\US\Kentucky\KentuckyIncome\KentuckyIncome;
 use Appleton\Taxes\Models\Countries\US\Kentucky\KentuckyIncomeTaxInformation;
@@ -10,7 +10,7 @@ use Appleton\Taxes\Tests\Unit\Countries\TaxTestCase;
 
 class KentuckyIncomeTest extends TaxTestCase
 {
-    private const DATE = '2019-01-01';
+    private const DATE = '2020-01-01';
     private const LOCATION = 'us.kentucky';
     private const TAX_CLASS = KentuckyIncome::class;
     private const TAX_INFO_CLASS = KentuckyIncomeTaxInformation::class;
@@ -49,28 +49,21 @@ class KentuckyIncomeTest extends TaxTestCase
                 $builder
                     ->setTaxInfoOptions(null)
                     ->setWagesInCents(16668)
-                    ->setExpectedAmountInCents(584)
+                    ->setExpectedAmountInCents(578)
                     ->build()
             ],
             'have not met standard deduction' => [
                 $builder
                     ->setTaxInfoOptions(null)
-                    ->setWagesInCents(4660)
-                    ->setExpectedAmountInCents(0)
-                    ->build()
-            ],
-            'meet standard deduction' => [
-                $builder
-                    ->setTaxInfoOptions(null)
-                    ->setWagesInCents(4981)
+                    ->setWagesInCents(5000)
                     ->setExpectedAmountInCents(0)
                     ->build()
             ],
             'exceed standard deduction' => [
                 $builder
                     ->setTaxInfoOptions(null)
-                    ->setWagesInCents(5301)
-                    ->setExpectedAmountInCents(16)
+                    ->setWagesInCents(5200)
+                    ->setExpectedAmountInCents(5)
                     ->build()
             ],
             'exempt' => [

--- a/tests/Unit/Countries/US/Kentucky/V20200101/KentuckyUnemploymentTest.php
+++ b/tests/Unit/Countries/US/Kentucky/V20200101/KentuckyUnemploymentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Appleton\Taxes\Tests\Unit\Countries\US\Kentucky\V20200101;
+
+use Appleton\Taxes\Countries\US\Kentucky\KentuckyUnemployment\KentuckyUnemployment;
+use Appleton\Taxes\Tests\Unit\Countries\UnemploymentTaxTestCase;
+use Appleton\Taxes\Tests\Unit\Countries\TestParameters;
+
+class KentuckyUnemploymentTest extends UnemploymentTaxTestCase
+{
+    private const DATE = '2020-01-01';
+    private const LOCATION = 'us.kentucky';
+    private const TAX_CLASS = KentuckyUnemployment::class;
+    private const TAX_RATE = 0.027;
+    private const WAGE_BASE = 1080000;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->query_runner->addTax(self::TAX_CLASS);
+    }
+
+    /**
+     * @dataProvider provideData
+     */
+    public function testWageBase(TestParameters $parameters): void
+    {
+        $this->validateWageBase($parameters);
+    }
+
+    public function testWorkDifferentState(): void
+    {
+        $this->validateWorkDifferentState(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::TAX_RATE
+        );
+    }
+
+    public function testTaxRate(): void
+    {
+        $this->validateTaxRate(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            0.0321
+        );
+    }
+
+    public function provideData(): array
+    {
+        return $this->wageBaseBoundariesTestCases(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::WAGE_BASE,
+            self::TAX_RATE);
+    }
+}

--- a/tests/Unit/Countries/US/Missouri/V20200101/MissouriUnemploymentTest.php
+++ b/tests/Unit/Countries/US/Missouri/V20200101/MissouriUnemploymentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Appleton\Taxes\Tests\Unit\Countries\US\Missouri\V20200101;
+
+use Appleton\Taxes\Countries\US\Missouri\MissouriUnemployment\MissouriUnemployment;
+use Appleton\Taxes\Tests\Unit\Countries\UnemploymentTaxTestCase;
+use Appleton\Taxes\Tests\Unit\Countries\TestParameters;
+
+class MissouriUnemploymentTest extends UnemploymentTaxTestCase
+{
+    private const DATE = '2020-01-01';
+    private const LOCATION = 'us.missouri';
+    private const TAX_CLASS = MissouriUnemployment::class;
+    private const TAX_RATE = 0.027;
+    private const WAGE_BASE = 1150000;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->query_runner->addTax(self::TAX_CLASS);
+    }
+
+    /**
+     * @dataProvider provideData
+     */
+    public function testWageBase(TestParameters $parameters): void
+    {
+        $this->validateWageBase($parameters);
+    }
+
+    public function testWorkDifferentState(): void
+    {
+        $this->validateWorkDifferentState(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::TAX_RATE
+        );
+    }
+
+    public function testTaxRate(): void
+    {
+        $this->validateTaxRate(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            0.0321
+        );
+    }
+
+    public function provideData(): array
+    {
+        return $this->wageBaseBoundariesTestCases(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::WAGE_BASE,
+            self::TAX_RATE);
+    }
+}

--- a/tests/Unit/Countries/US/Nevada/V20200101/NevadaUnemploymentTest.php
+++ b/tests/Unit/Countries/US/Nevada/V20200101/NevadaUnemploymentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Appleton\Taxes\Tests\Unit\Countries\US\Nevada\V20200101;
+
+use Appleton\Taxes\Countries\US\Nevada\NevadaUnemployment\NevadaUnemployment;
+use Appleton\Taxes\Tests\Unit\Countries\UnemploymentTaxTestCase;
+use Appleton\Taxes\Tests\Unit\Countries\TestParameters;
+
+class NevadaUnemploymentTest extends UnemploymentTaxTestCase
+{
+    private const DATE = '2020-01-01';
+    private const LOCATION = 'us.nevada';
+    private const TAX_CLASS = NevadaUnemployment::class;
+    private const TAX_RATE = 0.03;
+    private const WAGE_BASE = 3250000;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->query_runner->addTax(self::TAX_CLASS);
+    }
+
+    /**
+     * @dataProvider provideData
+     */
+    public function testWageBase(TestParameters $parameters): void
+    {
+        $this->validateWageBase($parameters);
+    }
+
+    public function testWorkDifferentState(): void
+    {
+        $this->validateWorkDifferentState(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::TAX_RATE
+        );
+    }
+
+    public function testTaxRate(): void
+    {
+        $this->validateTaxRate(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            0.0321
+        );
+    }
+
+    public function provideData(): array
+    {
+        return $this->wageBaseBoundariesTestCases(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::WAGE_BASE,
+            self::TAX_RATE);
+    }
+}

--- a/tests/Unit/Countries/US/NewJersey/V20200101/NewJerseyUnemploymentTest.php
+++ b/tests/Unit/Countries/US/NewJersey/V20200101/NewJerseyUnemploymentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Appleton\Taxes\Tests\Unit\Countries\US\NewJersey\V20200101;
+
+use Appleton\Taxes\Countries\US\NewJersey\NewJerseyUnemployment\NewJerseyUnemployment;
+use Appleton\Taxes\Tests\Unit\Countries\UnemploymentTaxTestCase;
+use Appleton\Taxes\Tests\Unit\Countries\TestParameters;
+
+class NewJerseyUnemploymentTest extends UnemploymentTaxTestCase
+{
+    private const DATE = '2020-01-01';
+    private const LOCATION = 'us.new_jersey';
+    private const TAX_CLASS = NewJerseyUnemployment::class;
+    private const TAX_RATE = 0.028;
+    private const WAGE_BASE = 3530000;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->query_runner->addTax(self::TAX_CLASS);
+    }
+
+    /**
+     * @dataProvider provideData
+     */
+    public function testWageBase(TestParameters $parameters): void
+    {
+        $this->validateWageBase($parameters);
+    }
+
+    public function testWorkDifferentState(): void
+    {
+        $this->validateWorkDifferentState(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::TAX_RATE
+        );
+    }
+
+    public function testTaxRate(): void
+    {
+        $this->validateTaxRate(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            0.0321
+        );
+    }
+
+    public function provideData(): array
+    {
+        return $this->wageBaseBoundariesTestCases(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::WAGE_BASE,
+            self::TAX_RATE);
+    }
+}

--- a/tests/Unit/Countries/US/NewMexico/V20200101/NewMexicoUnemploymentTest.php
+++ b/tests/Unit/Countries/US/NewMexico/V20200101/NewMexicoUnemploymentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Appleton\Taxes\Tests\Unit\Countries\US\NewMexico\V20200101;
+
+use Appleton\Taxes\Countries\US\NewMexico\NewMexicoUnemployment\NewMexicoUnemployment;
+use Appleton\Taxes\Tests\Unit\Countries\UnemploymentTaxTestCase;
+use Appleton\Taxes\Tests\Unit\Countries\TestParameters;
+
+class NewMexicoUnemploymentTest extends UnemploymentTaxTestCase
+{
+    private const DATE = '2020-01-01';
+    private const LOCATION = 'us.new_mexico';
+    private const TAX_CLASS = NewMexicoUnemployment::class;
+    private const TAX_RATE = 0.01;
+    private const WAGE_BASE = 2580000;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->query_runner->addTax(self::TAX_CLASS);
+    }
+
+    /**
+     * @dataProvider provideData
+     */
+    public function testWageBase(TestParameters $parameters): void
+    {
+        $this->validateWageBase($parameters);
+    }
+
+    public function testWorkDifferentState(): void
+    {
+        $this->validateWorkDifferentState(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::TAX_RATE
+        );
+    }
+
+    public function testTaxRate(): void
+    {
+        $this->validateTaxRate(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            0.0321
+        );
+    }
+
+    public function provideData(): array
+    {
+        return $this->wageBaseBoundariesTestCases(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::WAGE_BASE,
+            self::TAX_RATE);
+    }
+}

--- a/tests/Unit/Countries/US/NewYork/V20200101/NewYorkUnemploymentTest.php
+++ b/tests/Unit/Countries/US/NewYork/V20200101/NewYorkUnemploymentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Appleton\Taxes\Tests\Unit\Countries\US\NewYork\V20200101;
+
+use Appleton\Taxes\Countries\US\NewYork\NewYorkUnemployment\NewYorkUnemployment;
+use Appleton\Taxes\Tests\Unit\Countries\UnemploymentTaxTestCase;
+use Appleton\Taxes\Tests\Unit\Countries\TestParameters;
+
+class NewYorkUnemploymentTest extends UnemploymentTaxTestCase
+{
+    private const DATE = '2020-01-01';
+    private const LOCATION = 'us.new_york';
+    private const TAX_CLASS = NewYorkUnemployment::class;
+    private const TAX_RATE = 0.036;
+    private const WAGE_BASE = 1160000;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->query_runner->addTax(self::TAX_CLASS);
+    }
+
+    /**
+     * @dataProvider provideData
+     */
+    public function testWageBase(TestParameters $parameters): void
+    {
+        $this->validateWageBase($parameters);
+    }
+
+    public function testWorkDifferentState(): void
+    {
+        $this->validateWorkDifferentState(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::TAX_RATE
+        );
+    }
+
+    public function testTaxRate(): void
+    {
+        $this->validateTaxRate(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            0.0321
+        );
+    }
+
+    public function provideData(): array
+    {
+        return $this->wageBaseBoundariesTestCases(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::WAGE_BASE,
+            self::TAX_RATE);
+    }
+}

--- a/tests/Unit/Countries/US/NorthCarolina/V20180101/NorthCarolinaIncomeTest.php
+++ b/tests/Unit/Countries/US/NorthCarolina/V20180101/NorthCarolinaIncomeTest.php
@@ -77,7 +77,7 @@ class NorthCarolinaIncomeTest extends TaxTestCase
                 $builder
                     ->setTaxInfoOptions(null)
                     ->setWagesInCents(6668)
-                    ->setExpectedAmountInCents(181)
+                    ->setExpectedAmountInCents(200)
                     ->build()
             ],
             'additional withholding no wages' => [
@@ -91,7 +91,7 @@ class NorthCarolinaIncomeTest extends TaxTestCase
                 $builder
                     ->setTaxInfoOptions(['additional_withholding' => 10])
                     ->setWagesInCents(6668)
-                    ->setExpectedAmountInCents(1181)
+                    ->setExpectedAmountInCents(1200)
                     ->build()
             ],
             'non negative' => [
@@ -126,7 +126,7 @@ class NorthCarolinaIncomeTest extends TaxTestCase
                 $builder
                     ->setTaxInfoOptions(null)
                     ->setWagesInCents(6668)
-                    ->setExpectedAmountInCents(181)
+                    ->setExpectedAmountInCents(200)
                     ->build()
             ],
         ];

--- a/tests/Unit/Countries/US/NorthCarolina/V20200101/NorthCarolinaIncomeTest.php
+++ b/tests/Unit/Countries/US/NorthCarolina/V20200101/NorthCarolinaIncomeTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Appleton\Taxes\Tests\Unit\Countries\US\NorthCarolina\V20200101;
+
+use Appleton\Taxes\Countries\US\NorthCarolina\NorthCarolinaIncome\NorthCarolinaIncome;
+use Appleton\Taxes\Models\Countries\US\NorthCarolina\NorthCarolinaIncomeTaxInformation;
+use Appleton\Taxes\Tests\Unit\Countries\TestParameters;
+use Appleton\Taxes\Tests\Unit\Countries\TestParametersBuilder;
+use Appleton\Taxes\Tests\Unit\Countries\TaxTestCase;
+
+class NorthCarolinaIncomeTest extends TaxTestCase
+{
+    private const DATE = '2020-01-01';
+    private const LOCATION = 'us.north_carolina';
+    private const TAX_CLASS = NorthCarolinaIncome::class;
+    private const TAX_INFO_CLASS = NorthCarolinaIncomeTaxInformation::class;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->query_runner->addTax(self::TAX_CLASS);
+
+        NorthCarolinaIncomeTaxInformation::createForUser([
+             'filing_status' => NorthCarolinaIncome::FILING_SINGLE,
+             'dependents' => 0,
+             'additional_withholding' => 0,
+             'exempt' => false,
+         ], $this->user);
+    }
+
+    /**
+     * @dataProvider provideTestData
+     */
+    public function testTax(TestParameters $parameters): void
+    {
+        $this->validate($parameters);
+    }
+
+    public function provideTestData(): array
+    {
+        $builder = new TestParametersBuilder();
+        $builder
+            ->setDate(self::DATE)
+            ->setHomeLocation(self::LOCATION)
+            ->setTaxClass(self::TAX_CLASS)
+            ->setTaxInfoClass(self::TAX_INFO_CLASS)
+            ->setPayPeriods(52);
+
+        return [
+            'case study A' => [
+                $builder
+                    ->setTaxInfoOptions(null)
+                    ->setWagesInCents(27000)
+                    ->setExpectedAmountInCents(300)
+                    ->build()
+            ],
+            'case study B' => [
+                $builder
+                    ->setTaxInfoOptions(['dependents' => 3])
+                    ->setWagesInCents(78500)
+                    ->setExpectedAmountInCents(2800)
+                    ->build()
+            ],
+            'case study C' => [
+                $builder
+                    ->setTaxInfoOptions(['filing_status' => NorthCarolinaIncome::FILING_MARRIED])
+                    ->setWagesInCents(16080)
+                    ->setExpectedAmountInCents(0)
+                    ->build()
+            ],
+            'case study D' => [
+                $builder
+                    ->setTaxInfoOptions([
+                        'filing_status' => NorthCarolinaIncome::FILING_MARRIED,
+                        'dependents' => 5,
+                        'additional_withholding' => 15.00,
+                    ])
+                    ->setWagesInCents(28000)
+                    ->setExpectedAmountInCents(1500)
+                    ->build()
+            ],
+            'case study E' => [
+                $builder
+                    ->setTaxInfoOptions([
+                        'dependents' => 1,
+                        'additional_withholding' => 25.00,
+                    ])
+                    ->setWagesInCents(45500)
+                    ->setExpectedAmountInCents(3600)
+                    ->build()
+            ],
+            'case study F' => [
+                $builder
+                    ->setTaxInfoOptions(['filing_status' => NorthCarolinaIncome::FILING_MARRIED])
+                    ->setWagesInCents(36500)
+                    ->setExpectedAmountInCents(0)
+                    ->build()
+            ],
+            'case study G' => [
+                $builder
+                    ->setTaxInfoOptions([
+                        'filing_status' => NorthCarolinaIncome::FILING_SINGLE,
+                        'dependents' => 8,
+                    ])
+                    ->setWagesInCents(62500)
+                    ->setExpectedAmountInCents(1000)
+                    ->build()
+            ],
+        ];
+    }
+}

--- a/tests/Unit/Countries/US/NorthCarolina/V20200101/NorthCarolinaUnemploymentTest.php
+++ b/tests/Unit/Countries/US/NorthCarolina/V20200101/NorthCarolinaUnemploymentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Appleton\Taxes\Tests\Unit\Countries\US\NorthCarolina\V20200101;
+
+use Appleton\Taxes\Countries\US\NorthCarolina\NorthCarolinaUnemployment\NorthCarolinaUnemployment;
+use Appleton\Taxes\Tests\Unit\Countries\UnemploymentTaxTestCase;
+use Appleton\Taxes\Tests\Unit\Countries\TestParameters;
+
+class NorthCarolinaUnemploymentTest extends UnemploymentTaxTestCase
+{
+    private const DATE = '2020-01-01';
+    private const LOCATION = 'us.north_carolina';
+    private const TAX_CLASS = NorthCarolinaUnemployment::class;
+    private const TAX_RATE = 0.01;
+    private const WAGE_BASE = 2520000;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->query_runner->addTax(self::TAX_CLASS);
+    }
+
+    /**
+     * @dataProvider provideData
+     */
+    public function testWageBase(TestParameters $parameters): void
+    {
+        $this->validateWageBase($parameters);
+    }
+
+    public function testWorkDifferentState(): void
+    {
+        $this->validateWorkDifferentState(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::TAX_RATE
+        );
+    }
+
+    public function testTaxRate(): void
+    {
+        $this->validateTaxRate(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            0.0321
+        );
+    }
+
+    public function provideData(): array
+    {
+        return $this->wageBaseBoundariesTestCases(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::WAGE_BASE,
+            self::TAX_RATE);
+    }
+}

--- a/tests/Unit/Countries/US/Ohio/V20200101/OhioUnemploymentTest.php
+++ b/tests/Unit/Countries/US/Ohio/V20200101/OhioUnemploymentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Appleton\Taxes\Tests\Unit\Countries\US\Ohio\V20200101;
+
+use Appleton\Taxes\Countries\US\Ohio\OhioUnemployment\OhioUnemployment;
+use Appleton\Taxes\Tests\Unit\Countries\UnemploymentTaxTestCase;
+use Appleton\Taxes\Tests\Unit\Countries\TestParameters;
+
+class OhioUnemploymentTest extends UnemploymentTaxTestCase
+{
+    private const DATE = '2020-01-01';
+    private const LOCATION = 'us.ohio';
+    private const TAX_CLASS = OhioUnemployment::class;
+    private const TAX_RATE = 0.027;
+    private const WAGE_BASE = 900000;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->query_runner->addTax(self::TAX_CLASS);
+    }
+
+    /**
+     * @dataProvider provideData
+     */
+    public function testWageBase(TestParameters $parameters): void
+    {
+        $this->validateWageBase($parameters);
+    }
+
+    public function testWorkDifferentState(): void
+    {
+        $this->validateWorkDifferentState(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::TAX_RATE
+        );
+    }
+
+    public function testTaxRate(): void
+    {
+        $this->validateTaxRate(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            0.0321
+        );
+    }
+
+    public function provideData(): array
+    {
+        return $this->wageBaseBoundariesTestCases(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::WAGE_BASE,
+            self::TAX_RATE);
+    }
+}

--- a/tests/Unit/Countries/US/Oklahoma/V20200101/OklahomaUnemploymentTest.php
+++ b/tests/Unit/Countries/US/Oklahoma/V20200101/OklahomaUnemploymentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Appleton\Taxes\Tests\Unit\Countries\US\Oklahoma\V20200101;
+
+use Appleton\Taxes\Countries\US\Oklahoma\OklahomaUnemployment\OklahomaUnemployment;
+use Appleton\Taxes\Tests\Unit\Countries\UnemploymentTaxTestCase;
+use Appleton\Taxes\Tests\Unit\Countries\TestParameters;
+
+class OklahomaUnemploymentTest extends UnemploymentTaxTestCase
+{
+    private const DATE = '2020-01-01';
+    private const LOCATION = 'us.oklahoma';
+    private const TAX_CLASS = OklahomaUnemployment::class;
+    private const TAX_RATE = 0.015;
+    private const WAGE_BASE = 1870000;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->query_runner->addTax(self::TAX_CLASS);
+    }
+
+    /**
+     * @dataProvider provideData
+     */
+    public function testWageBase(TestParameters $parameters): void
+    {
+        $this->validateWageBase($parameters);
+    }
+
+    public function testWorkDifferentState(): void
+    {
+        $this->roundedValidateWorkDifferentState(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::TAX_RATE
+        );
+    }
+
+    public function testTaxRate(): void
+    {
+        $this->roundedValidateTaxRate(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            0.0321
+        );
+    }
+
+    public function provideData(): array
+    {
+        return $this->roundedWageBaseBoundariesTestCases(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::WAGE_BASE,
+            self::TAX_RATE);
+    }
+}

--- a/tests/Unit/Countries/US/Oregon/V20190101/OregonUnemploymentTest.php
+++ b/tests/Unit/Countries/US/Oregon/V20190101/OregonUnemploymentTest.php
@@ -38,16 +38,6 @@ class OregonUnemploymentTest extends UnemploymentTaxTestCase
         );
     }
 
-    public function testTaxRate(): void
-    {
-        $this->validateTaxRate(
-            self::DATE,
-            self::LOCATION,
-            self::TAX_CLASS,
-            0.0321
-        );
-    }
-
     public function provideData(): array
     {
         return $this->wageBaseBoundariesTestCases(

--- a/tests/Unit/Countries/US/Oregon/V20200101/OregonUnemploymentTest.php
+++ b/tests/Unit/Countries/US/Oregon/V20200101/OregonUnemploymentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Appleton\Taxes\Tests\Unit\Countries\US\Oregon\V20200101;
+
+use Appleton\Taxes\Countries\US\Oregon\OregonUnemployment\OregonUnemployment;
+use Appleton\Taxes\Tests\Unit\Countries\UnemploymentTaxTestCase;
+use Appleton\Taxes\Tests\Unit\Countries\TestParameters;
+
+class OregonUnemploymentTest extends UnemploymentTaxTestCase
+{
+    private const DATE = '2020-01-01';
+    private const LOCATION = 'us.oregon';
+    private const TAX_CLASS = OregonUnemployment::class;
+    private const TAX_RATE = 0.024;
+    private const WAGE_BASE = 4210000;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->query_runner->addTax(self::TAX_CLASS);
+    }
+
+    /**
+     * @dataProvider provideData
+     */
+    public function testWageBase(TestParameters $parameters): void
+    {
+        $this->validateWageBase($parameters);
+    }
+
+    public function testWorkDifferentState(): void
+    {
+        $this->validateWorkDifferentState(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::TAX_RATE
+        );
+    }
+
+    public function testTaxRate(): void
+    {
+        $this->validateTaxRate(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            0.0321
+        );
+    }
+
+    public function provideData(): array
+    {
+        return $this->wageBaseBoundariesTestCases(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::WAGE_BASE,
+            self::TAX_RATE);
+    }
+}

--- a/tests/Unit/Countries/US/Oregon/V20200101/OregonUnemploymentTest.php
+++ b/tests/Unit/Countries/US/Oregon/V20200101/OregonUnemploymentTest.php
@@ -11,7 +11,7 @@ class OregonUnemploymentTest extends UnemploymentTaxTestCase
     private const DATE = '2020-01-01';
     private const LOCATION = 'us.oregon';
     private const TAX_CLASS = OregonUnemployment::class;
-    private const TAX_RATE = 0.024;
+    private const TAX_RATE = 0.021;
     private const WAGE_BASE = 4210000;
 
     public function setUp(): void

--- a/tests/Unit/Countries/US/SocialSecurity/V20200101/SocialSecurityEmployerTest.php
+++ b/tests/Unit/Countries/US/SocialSecurity/V20200101/SocialSecurityEmployerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Appleton\Taxes\Tests\Unit\Countries\US\SocialSecurity\V20200101;
+
+use Appleton\Taxes\Countries\US\SocialSecurity\SocialSecurityEmployer;
+use Appleton\Taxes\Tests\Unit\Countries\TestParameters;
+use Appleton\Taxes\Tests\Unit\Countries\TestParametersBuilder;
+use Appleton\Taxes\Tests\Unit\Countries\TaxTestCase;
+
+class SocialSecurityEmployerTest extends TaxTestCase
+{
+    private const DATE = '2020-01-01';
+    private const LOCATION = 'us';
+    private const TAX_CLASS = SocialSecurityEmployer::class;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->query_runner->addTax(self::TAX_CLASS);
+    }
+
+    /**
+     * @dataProvider provideData
+     */
+    public function testWageBase(TestParameters $parameters): void
+    {
+        $this->validate($parameters);
+    }
+
+    public function provideData(): array
+    {
+        $builder = new TestParametersBuilder();
+        $builder
+            ->setDate(self::DATE)
+            ->setHomeLocation(self::LOCATION)
+            ->setTaxClass(self::TAX_CLASS)
+            ->setPayPeriods(52);
+
+        return [
+            'case study A' => [
+                $builder
+                    ->setWagesInCents(64000)
+                    ->setYtdWagesInCents(0)
+                    ->setExpectedAmountInCents(3968)
+                    ->setExpectedEarningsInCents(64000)
+                    ->build()
+            ],
+            'case study B' => [
+                $builder
+                    ->setWagesInCents(77428)
+                    ->setYtdWagesInCents(0)
+                    ->setExpectedAmountInCents(4801)
+                    ->setExpectedEarningsInCents(77428)
+                    ->build()
+            ],
+            'case study C' => [
+                $builder
+                    ->setWagesInCents(64000)
+                    ->setYtdWagesInCents(13300000)
+                    ->setExpectedAmountInCents(3968)
+                    ->setExpectedEarningsInCents(64000)
+                    ->build()
+            ],
+            'case study D' => [
+                $builder
+                    ->setWagesInCents(77428)
+                    ->setYtdWagesInCents(13300000)
+                    ->setExpectedAmountInCents(4801)
+                    ->setExpectedEarningsInCents(77428)
+                    ->build()
+            ],
+            'under wage base' => [
+                $builder
+                    ->setWagesInCents(10000)
+                    ->setYtdWagesInCents(13769999)
+                    ->setExpectedAmountInCents(0)
+                    ->setExpectedEarningsInCents(1)
+                    ->build()
+            ],
+            'at wage base' => [
+                $builder
+                    ->setWagesInCents(10000)
+                    ->setYtdWagesInCents(13770000)
+                    ->setExpectedAmountInCents(0)
+                    ->setExpectedEarningsInCents(0)
+                    ->build()
+            ],
+            'over wage base' => [
+                $builder
+                    ->setWagesInCents(10000)
+                    ->setYtdWagesInCents(13770001)
+                    ->setExpectedAmountInCents(0)
+                    ->setExpectedEarningsInCents(0)
+                    ->build()
+            ],
+        ];
+    }
+}

--- a/tests/Unit/Countries/US/SocialSecurity/V20200101/SocialSecurityTest.php
+++ b/tests/Unit/Countries/US/SocialSecurity/V20200101/SocialSecurityTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Appleton\Taxes\Tests\Unit\Countries\US\SocialSecurity\V20200101;
+
+use Appleton\Taxes\Countries\US\SocialSecurity\SocialSecurity;
+use Appleton\Taxes\Tests\Unit\Countries\TestParameters;
+use Appleton\Taxes\Tests\Unit\Countries\TestParametersBuilder;
+use Appleton\Taxes\Tests\Unit\Countries\TaxTestCase;
+
+class SocialSecurityTest extends TaxTestCase
+{
+    private const DATE = '2020-01-01';
+    private const LOCATION = 'us';
+    private const TAX_CLASS = SocialSecurity::class;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->query_runner->addTax(self::TAX_CLASS);
+    }
+
+    /**
+     * @dataProvider provideTestData
+     */
+    public function testTax(TestParameters $parameters): void
+    {
+        $this->validate($parameters);
+    }
+
+    public function provideTestData(): array
+    {
+        $builder = new TestParametersBuilder();
+        $builder
+            ->setDate(self::DATE)
+            ->setHomeLocation(self::LOCATION)
+            ->setTaxClass(self::TAX_CLASS)
+            ->setPayPeriods(52);
+
+        return [
+            'case study A' => [
+                $builder
+                    ->setWagesInCents(64000)
+                    ->setYtdWagesInCents(0)
+                    ->setExpectedAmountInCents(3968)
+                    ->setExpectedEarningsInCents(64000)
+                    ->build()
+            ],
+            'case study B' => [
+                $builder
+                    ->setWagesInCents(77428)
+                    ->setYtdWagesInCents(0)
+                    ->setExpectedAmountInCents(4801)
+                    ->setExpectedEarningsInCents(77428)
+                    ->build()
+            ],
+            'case study C' => [
+                $builder
+                    ->setWagesInCents(64000)
+                    ->setYtdWagesInCents(13300000)
+                    ->setExpectedAmountInCents(3968)
+                    ->setExpectedEarningsInCents(64000)
+                    ->build()
+            ],
+            'case study D' => [
+                $builder
+                    ->setWagesInCents(77428)
+                    ->setYtdWagesInCents(13300000)
+                    ->setExpectedAmountInCents(4801)
+                    ->setExpectedEarningsInCents(77428)
+                    ->build()
+            ],
+            'under wage base' => [
+                $builder
+                    ->setWagesInCents(10000)
+                    ->setYtdWagesInCents(13769999)
+                    ->setExpectedAmountInCents(0)
+                    ->setExpectedEarningsInCents(1)
+                    ->build()
+            ],
+            'at wage base' => [
+                $builder
+                    ->setWagesInCents(10000)
+                    ->setYtdWagesInCents(13770000)
+                    ->setExpectedAmountInCents(0)
+                    ->setExpectedEarningsInCents(0)
+                    ->build()
+            ],
+            'over wage base' => [
+                $builder
+                    ->setWagesInCents(10000)
+                    ->setYtdWagesInCents(13770001)
+                    ->setExpectedAmountInCents(0)
+                    ->setExpectedEarningsInCents(0)
+                    ->build()
+            ],
+        ];
+    }
+}

--- a/tests/Unit/Countries/US/Vermont/V20200101/VermontUnemploymentTest.php
+++ b/tests/Unit/Countries/US/Vermont/V20200101/VermontUnemploymentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Appleton\Taxes\Tests\Unit\Countries\US\Vermont\V20200101;
+
+use Appleton\Taxes\Countries\US\Vermont\VermontUnemployment\VermontUnemployment;
+use Appleton\Taxes\Tests\Unit\Countries\UnemploymentTaxTestCase;
+use Appleton\Taxes\Tests\Unit\Countries\TestParameters;
+
+class VermontUnemploymentTest extends UnemploymentTaxTestCase
+{
+    private const DATE = '2020-01-01';
+    private const LOCATION = 'us.vermont';
+    private const TAX_CLASS = VermontUnemployment::class;
+    private const TAX_RATE = 0.01;
+    private const WAGE_BASE = 1610000;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->query_runner->addTax(self::TAX_CLASS);
+    }
+
+    /**
+     * @dataProvider provideData
+     */
+    public function testWageBase(TestParameters $parameters): void
+    {
+        $this->validateWageBase($parameters);
+    }
+
+    public function testWorkDifferentState(): void
+    {
+        $this->validateWorkDifferentState(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::TAX_RATE
+        );
+    }
+
+    public function testTaxRate(): void
+    {
+        $this->validateTaxRate(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            0.0321
+        );
+    }
+
+    public function provideData(): array
+    {
+        return $this->wageBaseBoundariesTestCases(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::WAGE_BASE,
+            self::TAX_RATE);
+    }
+}

--- a/tests/Unit/Countries/US/Wyoming/V20200101/WyomingUnemploymentTest.php
+++ b/tests/Unit/Countries/US/Wyoming/V20200101/WyomingUnemploymentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Appleton\Taxes\Tests\Unit\Countries\US\Wyoming\V20200101;
+
+use Appleton\Taxes\Countries\US\Wyoming\WyomingUnemployment\WyomingUnemployment;
+use Appleton\Taxes\Tests\Unit\Countries\UnemploymentTaxTestCase;
+use Appleton\Taxes\Tests\Unit\Countries\TestParameters;
+
+class WyomingUnemploymentTest extends UnemploymentTaxTestCase
+{
+    private const DATE = '2020-01-01';
+    private const LOCATION = 'us.wyoming';
+    private const TAX_CLASS = WyomingUnemployment::class;
+    private const TAX_RATE = 0.0122;
+    private const WAGE_BASE = 2640000;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->query_runner->addTax(self::TAX_CLASS);
+    }
+
+    /**
+     * @dataProvider provideData
+     */
+    public function testWageBase(TestParameters $parameters): void
+    {
+        $this->validateWageBase($parameters);
+    }
+
+    public function testWorkDifferentState(): void
+    {
+        $this->validateWorkDifferentState(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::TAX_RATE
+        );
+    }
+
+    public function testTaxRate(): void
+    {
+        $this->validateTaxRate(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            0.0321
+        );
+    }
+
+    public function provideData(): array
+    {
+        return $this->wageBaseBoundariesTestCases(
+            self::DATE,
+            self::LOCATION,
+            self::TAX_CLASS,
+            self::WAGE_BASE,
+            self::TAX_RATE);
+    }
+}


### PR DESCRIPTION
# Tickets
[2020 SUTA Rate and Wage Base Updates](https://spurjob.atlassian.net/browse/ACC-545)
[2020 Social Security Wage Base Update](https://spurjob.atlassian.net/browse/ACC-548)
[2020 State Income Standard Deduction Changes: North Carolina and Kentucky](https://spurjob.atlassian.net/browse/ACC-546)

# Changes
* Update tax numbers for 2020
* Moved calculation logic to parent classes
* Separated SS and SS Employer for consistency with other taxes

# Notes
In order to get tests to pass for the SUTA wage base updates for Oregon (standard new employer rate changed) I made 2019 not look at the env property. Not sure if this is the solution we want or not.