### PR TITLE
LAWS-111 update Arkansas Income bracket:

### DIFF
--- a/src/Countries/US/Arkansas/ArkansasIncome/V20190101/ArkansasIncome.php
+++ b/src/Countries/US/Arkansas/ArkansasIncome/V20190101/ArkansasIncome.php
@@ -13,12 +13,18 @@ class ArkansasIncome extends BaseArkansasIncome
     private const EXEMPTION_AMOUNT = 26;
 
     private const BRACKETS = [
-        [0, 0.009, 0],
-        [4300, 0.024, 64.49],
-        [8400, 0.034, 148.48],
-        [12600, 0.044, 274.47],
-        [21000, 0.059, 589.45],
-        [35100, 0.069, 940.44],
+        [0, 0.00, 0],
+        [4300, 0.02, 91.98],
+        [9100, 0.03, 182.97],
+        [13700, 0.034, 237.77],
+        [22600, 0.05, 421.46],
+        [37900, 0.059, 762.55],
+        [80801, 0.066, 1243.4],
+        [81801, 0.066, 1143.4],
+        [82801, 0.066, 1043.4],
+        [84101, 0.066, 943.4],
+        [85201, 0.066, 843.4],
+        [86201, 0.066, 803.4],
     ];
 
     private const ARKANSAS = 'Arkansas';
@@ -38,10 +44,10 @@ class ArkansasIncome extends BaseArkansasIncome
                 if ($this->tax_information->ar_tx_exempt) {
                     return $this->payroll->withholdTax(0.0);
                 }
-            } else if (!$this->payroll->hasWorkInArea(self::ARKANSAS)) {
+            } elseif (!$this->payroll->hasWorkInArea(self::ARKANSAS)) {
                 return $this->payroll->withholdTax(0.0);
             }
-        } else if ($this->payroll->livesInArea(self::TEXARKANA_TX)) {
+        } elseif ($this->payroll->livesInArea(self::TEXARKANA_TX)) {
             $annual_gross -= $this->payroll->getEarningsForArea(self::TEXARKANA_AR) * $this->payroll->pay_periods;
         }
 
@@ -75,7 +81,7 @@ class ArkansasIncome extends BaseArkansasIncome
 
     private function get50MidRange(int $amount): int
     {
-        if ($amount >= 50000) {
+        if ($amount >= 87000) {
             return $amount;
         }
 

--- a/src/Models/Countries/US/Arkansas/ArkansasIncomeTaxInformation.php
+++ b/src/Models/Countries/US/Arkansas/ArkansasIncomeTaxInformation.php
@@ -16,6 +16,7 @@ class ArkansasIncomeTaxInformation extends BaseTaxInformationModel
         $tax_information->additional_withholding = 0;
         $tax_information->exempt = false;
         $tax_information->ar_tx_exempt = false;
+        $tax_information->low_income = false;
         return $tax_information;
     }
 

--- a/src/migrations/2020_01_30_000000_add_low_income_to arkansas.php
+++ b/src/migrations/2020_01_30_000000_add_low_income_to arkansas.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddLowIncomeToArkansas extends Migration
+{
+    public function up()
+    {
+        Schema::table('arkansas_income_tax_information', function (Blueprint $table) {
+            $table->boolean('low_income')->default(false);
+        });
+    }
+}

--- a/tests/Unit/Countries/US/Arkansas/V20190101/ArkansasIncomeTest.php
+++ b/tests/Unit/Countries/US/Arkansas/V20190101/ArkansasIncomeTest.php
@@ -6,8 +6,6 @@ use Appleton\Taxes\Classes\WorkerTaxes\GeoPoint;
 use Appleton\Taxes\Classes\WorkerTaxes\TaxResult;
 use Appleton\Taxes\Countries\US\Arkansas\ArkansasIncome\ArkansasIncome;
 use Appleton\Taxes\Models\Countries\US\Arkansas\ArkansasIncomeTaxInformation;
-use Appleton\Taxes\Tests\Unit\Countries\IncomeParameters;
-use Appleton\Taxes\Tests\Unit\Countries\IncomeParametersBuilder;
 use Appleton\Taxes\Tests\Unit\Countries\TaxTestCase;
 use Appleton\Taxes\Tests\Unit\Countries\TestParameters;
 use Appleton\Taxes\Tests\Unit\Countries\TestParametersBuilder;
@@ -96,8 +94,11 @@ class ArkansasIncomeTest extends TaxTestCase
         $result = $results->get(ArkansasIncome::class);
 
         self::assertNotNull($result, 'no tax results for '.$short_name.' found');
-        self::assertThat($result->getAmountInCents(), self::identicalTo(52),
-            $short_name.' expected 52 tax amount but got '.$result->getAmountInCents());
+        self::assertThat(
+            $result->getAmountInCents(),
+            self::identicalTo(0),
+            $short_name.' expected 0 tax amount but got '.$result->getAmountInCents()
+        );
     }
 
     public function provideTestData(): array
@@ -115,7 +116,7 @@ class ArkansasIncomeTest extends TaxTestCase
                 $builder
                     ->setTaxInfoOptions(null)
                     ->setWagesInCents(96154)
-                    ->setExpectedAmountInCents(4540)
+                    ->setExpectedAmountInCents(3962)
                     ->build()
             ],
             'test case 2' => [
@@ -124,49 +125,49 @@ class ArkansasIncomeTest extends TaxTestCase
                         'exemptions' => 3,
                     ])
                     ->setWagesInCents(96154)
-                    ->setExpectedAmountInCents(4390)
+                    ->setExpectedAmountInCents(3812)
                     ->build()
             ],
             'bracket 1' => [
                 $builder
                     ->setTaxInfoOptions(null)
                     ->setWagesInCents(7500)
-                    ->setExpectedAmountInCents(30)
+                    ->setExpectedAmountInCents(0)
                     ->build()
             ],
             'bracket 2' => [
                 $builder
                     ->setTaxInfoOptions(null)
                     ->setWagesInCents(17500)
-                    ->setExpectedAmountInCents(196)
+                    ->setExpectedAmountInCents(90)
                     ->build()
             ],
             'bracket 3' => [
                 $builder
                     ->setTaxInfoOptions(null)
                     ->setWagesInCents(27500)
-                    ->setExpectedAmountInCents(508)
+                    ->setExpectedAmountInCents(349)
                     ->build()
             ],
             'bracket 4' => [
                 $builder
                     ->setTaxInfoOptions(null)
                     ->setWagesInCents(40000)
-                    ->setExpectedAmountInCents(1050)
+                    ->setExpectedAmountInCents(762)
                     ->build()
             ],
             'bracket 5' => [
                 $builder
                     ->setTaxInfoOptions(null)
                     ->setWagesInCents(70000)
-                    ->setExpectedAmountInCents(2752)
+                    ->setExpectedAmountInCents(2482)
                     ->build()
             ],
             'bracket 6' => [
                 $builder
                     ->setTaxInfoOptions(null)
                     ->setWagesInCents(100000)
-                    ->setExpectedAmountInCents(4806)
+                    ->setExpectedAmountInCents(4189)
                     ->build()
             ],
             'additional withholding' => [
@@ -175,7 +176,7 @@ class ArkansasIncomeTest extends TaxTestCase
                         'additional_withholding' => 10,
                     ])
                     ->setWagesInCents(96154)
-                    ->setExpectedAmountInCents(5540)
+                    ->setExpectedAmountInCents(4962)
                     ->build()
             ],
             'exempt' => [
@@ -205,8 +206,8 @@ class ArkansasIncomeTest extends TaxTestCase
                     ->setHomeLocation(self::LOCATION_ARKANSAS_TEXARKANA)
                     ->setWorkLocation(self::LOCATION_ARKANSAS_TEXARKANA)
                     ->setTaxInfoOptions(['ar_tx_exempt' => false])
-                    ->setWagesInCents(7500)
-                    ->setExpectedAmountInCents(30)
+                    ->setWagesInCents(75000)
+                    ->setExpectedAmountInCents(2732)
                     ->build()
             ],
             '02' => [
@@ -214,8 +215,8 @@ class ArkansasIncomeTest extends TaxTestCase
                     ->setHomeLocation(self::LOCATION_ARKANSAS_TEXARKANA)
                     ->setWorkLocation(self::LOCATION_ARKANSAS)
                     ->setTaxInfoOptions(['ar_tx_exempt' => false])
-                    ->setWagesInCents(7500)
-                    ->setExpectedAmountInCents(30)
+                    ->setWagesInCents(75000)
+                    ->setExpectedAmountInCents(2732)
                     ->build()
             ],
             '03' => [
@@ -223,8 +224,8 @@ class ArkansasIncomeTest extends TaxTestCase
                     ->setHomeLocation(self::LOCATION_ARKANSAS)
                     ->setWorkLocation(self::LOCATION_ARKANSAS_TEXARKANA)
                     ->setTaxInfoOptions(['ar_tx_exempt' => false])
-                    ->setWagesInCents(7500)
-                    ->setExpectedAmountInCents(30)
+                    ->setWagesInCents(75000)
+                    ->setExpectedAmountInCents(2732)
                     ->build()
             ],
             '04' => [
@@ -232,7 +233,7 @@ class ArkansasIncomeTest extends TaxTestCase
                     ->setHomeLocation(self::LOCATION_TEXAS_TEXARKANA)
                     ->setWorkLocation(self::LOCATION_ARKANSAS_TEXARKANA)
                     ->setTaxInfoOptions(['ar_tx_exempt' => false])
-                    ->setWagesInCents(7500)
+                    ->setWagesInCents(75000)
                     ->setExpectedAmountInCents(0)
                     ->build()
             ],
@@ -241,8 +242,8 @@ class ArkansasIncomeTest extends TaxTestCase
                     ->setHomeLocation(self::LOCATION_TEXAS)
                     ->setWorkLocation(self::LOCATION_ARKANSAS_TEXARKANA)
                     ->setTaxInfoOptions(['ar_tx_exempt' => false])
-                    ->setWagesInCents(7500)
-                    ->setExpectedAmountInCents(30)
+                    ->setWagesInCents(75000)
+                    ->setExpectedAmountInCents(2732)
                     ->build()
             ],
             '06' => [
@@ -250,8 +251,8 @@ class ArkansasIncomeTest extends TaxTestCase
                     ->setHomeLocation(self::LOCATION_ARKANSAS_TEXARKANA)
                     ->setWorkLocation(self::LOCATION_TEXAS)
                     ->setTaxInfoOptions(['ar_tx_exempt' => false])
-                    ->setWagesInCents(7500)
-                    ->setExpectedAmountInCents(30)
+                    ->setWagesInCents(75000)
+                    ->setExpectedAmountInCents(2732)
                     ->build()
             ],
             '07' => [
@@ -259,8 +260,8 @@ class ArkansasIncomeTest extends TaxTestCase
                     ->setHomeLocation(self::LOCATION_ARKANSAS_TEXARKANA)
                     ->setWorkLocation(self::LOCATION_TEXAS_TEXARKANA)
                     ->setTaxInfoOptions(['ar_tx_exempt' => false])
-                    ->setWagesInCents(7500)
-                    ->setExpectedAmountInCents(30)
+                    ->setWagesInCents(75000)
+                    ->setExpectedAmountInCents(2732)
                     ->build()
             ],
             '08' => [
@@ -268,7 +269,7 @@ class ArkansasIncomeTest extends TaxTestCase
                     ->setHomeLocation(self::LOCATION_ARKANSAS_TEXARKANA)
                     ->setWorkLocation(self::LOCATION_TEXAS_TEXARKANA)
                     ->setTaxInfoOptions(['ar_tx_exempt' => true])
-                    ->setWagesInCents(7500)
+                    ->setWagesInCents(75000)
                     ->setExpectedAmountInCents(0)
                     ->build()
             ],
@@ -277,7 +278,7 @@ class ArkansasIncomeTest extends TaxTestCase
                     ->setHomeLocation(self::LOCATION_ARKANSAS)
                     ->setWorkLocation(self::LOCATION_TEXAS)
                     ->setTaxInfoOptions(['ar_tx_exempt' => false])
-                    ->setWagesInCents(7500)
+                    ->setWagesInCents(75000)
                     ->setExpectedAmountInCents(0)
                     ->build()
             ],
@@ -286,7 +287,7 @@ class ArkansasIncomeTest extends TaxTestCase
                     ->setHomeLocation(self::LOCATION_ARKANSAS)
                     ->setWorkLocation(self::LOCATION_TEXAS_TEXARKANA)
                     ->setTaxInfoOptions(['ar_tx_exempt' => false])
-                    ->setWagesInCents(7500)
+                    ->setWagesInCents(75000)
                     ->setExpectedAmountInCents(0)
                     ->build()
             ],


### PR DESCRIPTION
refs: https://spurjob.atlassian.net/browse/LAWS-111

Good news is since we don't have any workers in Arkansas we won't have to account for both forms, just the 2020 form and values

The low income is because there is a check box on the form that says check for low income tax bracket. But there is no tax bracket so Donnie wants to save what they select