### PR TITLE
LAWS-18 Add local exempt to MD

### DIFF
--- a/src/Models/Countries/US/Maryland/MarylandIncomeTaxInformation.php
+++ b/src/Models/Countries/US/Maryland/MarylandIncomeTaxInformation.php
@@ -16,6 +16,7 @@ class MarylandIncomeTaxInformation extends BaseTaxInformationModel
         $tax_information->additional_withholding = 0;
         $tax_information->filing_status = MarylandIncome::FILING_SINGLE;
         $tax_information->exempt = false;
+        $tax_information->local_exempt = false;
         return $tax_information;
     }
 

--- a/src/migrations/2020_02_03_000000_add_local_exempt_to_maryland.php
+++ b/src/migrations/2020_02_03_000000_add_local_exempt_to_maryland.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddLocalExemptToMaryland extends Migration
+{
+    public function up()
+    {
+        Schema::table('maryland_income_tax_information', function (Blueprint $table) {
+            $table->boolean('local_exempt')->default(false);
+        });
+    }
+}

--- a/tests/Unit/Countries/US/Maryland/V20190101/AlleganyTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/AlleganyTest.php
@@ -45,4 +45,21 @@ class AlleganyTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/AnneArundelTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/AnneArundelTest.php
@@ -45,4 +45,21 @@ class AnneArundelTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/BaltimoreCityTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/BaltimoreCityTest.php
@@ -45,4 +45,21 @@ class BaltimoreCityTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/BaltimoreTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/BaltimoreTest.php
@@ -45,4 +45,21 @@ class BaltimoreTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/CalvertTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/CalvertTest.php
@@ -45,4 +45,21 @@ class CalvertTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/CarolineTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/CarolineTest.php
@@ -45,4 +45,21 @@ class CarolineTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/CarrollTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/CarrollTest.php
@@ -45,4 +45,21 @@ class CarrollTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/CecilTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/CecilTest.php
@@ -45,4 +45,21 @@ class CecilTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/CharlesTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/CharlesTest.php
@@ -45,4 +45,21 @@ class CharlesTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/DorchesterTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/DorchesterTest.php
@@ -45,4 +45,21 @@ class DorchesterTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/FrederickTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/FrederickTest.php
@@ -45,4 +45,21 @@ class FrederickTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/GarrettTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/GarrettTest.php
@@ -45,4 +45,21 @@ class GarrettTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/HarfordTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/HarfordTest.php
@@ -45,4 +45,21 @@ class HarfordTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/HowardTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/HowardTest.php
@@ -45,4 +45,21 @@ class HowardTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/KentTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/KentTest.php
@@ -45,4 +45,21 @@ class KentTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/MontgomeryTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/MontgomeryTest.php
@@ -45,4 +45,21 @@ class MontgomeryTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/PrinceGeorgesTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/PrinceGeorgesTest.php
@@ -45,4 +45,21 @@ class PrinceGeorgesTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/QueenAnnesTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/QueenAnnesTest.php
@@ -45,4 +45,21 @@ class QueenAnnesTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/SomersetTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/SomersetTest.php
@@ -45,4 +45,21 @@ class SomersetTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/StMarysTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/StMarysTest.php
@@ -45,4 +45,21 @@ class StMarysTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/TalbotTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/TalbotTest.php
@@ -45,4 +45,21 @@ class TalbotTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/WashingtonTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/WashingtonTest.php
@@ -45,4 +45,21 @@ class WashingtonTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/WicomicoTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/WicomicoTest.php
@@ -45,4 +45,21 @@ class WicomicoTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }

--- a/tests/Unit/Countries/US/Maryland/V20190101/WorcesterTest.php
+++ b/tests/Unit/Countries/US/Maryland/V20190101/WorcesterTest.php
@@ -45,4 +45,21 @@ class WorcesterTest extends TaxTestCase
                 ->build()
         );
     }
+
+    public function testTaxLocalExempt(): void
+    {
+        $this->validate(
+            (new TestParametersBuilder())
+                ->setDate(self::DATE)
+                ->setHomeLocation(self::HOME_LOCATION)
+                ->setHomeLocation(self::WORK_LOCATION)
+                ->setTaxClass(self::TAX_CLASS)
+                ->setTaxInfoClass(self::TAX_INFO_CLASS)
+                ->setTaxInfoOptions(['local_exempt' => true])
+                ->setPayPeriods(52)
+                ->setWagesInCents(30000)
+                ->setExpectedAmountInCents(0)
+                ->build()
+        );
+    }
 }


### PR DESCRIPTION
refs: https://spurjob.atlassian.net/browse/LAWS-118

On the MD form there is an option for exempt from state taxes and an option for exempt from local taxes, previously if the tax library saw exempt it would exempt you from both state and local. After talking with pgrew and Donnie we decided to separate the logic to allow workers to be either exempt from the state or local taxes.