### PR TITLE
LAWS-202 Iowa 2020 tax library changes

### DIFF
--- a/src/Countries/US/Iowa/IowaIncome/V20200101/IowaIncome.php
+++ b/src/Countries/US/Iowa/IowaIncome/V20200101/IowaIncome.php
@@ -1,0 +1,65 @@
+<?php
+namespace Appleton\Taxes\Countries\US\Iowa\IowaIncome\V20200101;
+
+use Appleton\Taxes\Classes\WorkerTaxes\Payroll;
+use Appleton\Taxes\Countries\US\FederalIncome\FederalIncome;
+use Appleton\Taxes\Countries\US\Iowa\IowaIncome\IowaIncome as BaseIowaIncome;
+use Appleton\Taxes\Models\Countries\US\Iowa\IowaIncomeTaxInformation;
+use Illuminate\Database\Eloquent\Collection;
+
+class IowaIncome extends BaseIowaIncome
+{
+    const DEDUCTION_AMOUNT = 40;
+    const ZERO_OR_ONE = 1880;
+    const TWO_OR_MORE = 4630;
+
+    const TAX_WITHHOLDING_BRACKET = [
+        [0, 0.0033, 0],
+        [1480, .0067, 4.88],
+        [2959, .0225, 14.79],
+        [5918, .0414, 81.37],
+        [13316, .0563, 387.65],
+        [22193, .0596, 887.43],
+        [29590, .0625, 1328.29],
+        [44385, .0744, 2252.98],
+        [66578, .0853, 3904.14],
+    ];
+
+    public function __construct(IowaIncomeTaxInformation $tax_information, FederalIncome $federal_income, Payroll $payroll)
+    {
+        parent::__construct($tax_information, $payroll);
+        $this->federal_income_tax = $federal_income->getAmount();
+        $this->tax_information = $tax_information;
+    }
+
+    public function getTaxBrackets()
+    {
+        return self::TAX_WITHHOLDING_BRACKET;
+    }
+
+    public function compute(Collection $tax_areas)
+    {
+        if ($this->isUserClaimingExemption()) {
+            return 0;
+        }
+
+        $this->tax_total = $this->payroll->withholdTax(($this->getTaxAmountFromTaxBrackets($this->getGrossAnnualWages() - $this->getStandardAllowance(), $this->getTaxBrackets()) - $this->getExemptionAllowance()) / $this->payroll->pay_periods) + $this->tax_information-> additional_withholding;
+
+        return round($this->tax_total, 2);
+    }
+
+    public function getGrossAnnualWages()
+    {
+        return (($this->getAdjustedEarnings() * $this->payroll->pay_periods) - ($this->federal_income_tax * $this->payroll->pay_periods));
+    }
+
+    public function getStandardAllowance()
+    {
+        return $this->tax_information->allowances <= 1 ? self::ZERO_OR_ONE : self::TWO_OR_MORE;
+    }
+
+    public function getExemptionAllowance()
+    {
+        return self::DEDUCTION_AMOUNT * $this->tax_information->allowances;
+    }
+}

--- a/src/migrations/2020_04_06_000000_add_parameters_to_iowa_tax_income_information.php
+++ b/src/migrations/2020_04_06_000000_add_parameters_to_iowa_tax_income_information.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddParametersToIowaTaxIncomeInformation extends Migration
+{
+    protected $iowa_income_tax_information = 'iowa_income_tax_information';
+
+    public function up()
+    {
+        Schema::table($this->iowa_income_tax_information, function (Blueprint $table) {
+            $table->integer('additional_withholding')->default(0);
+        });
+    }
+}

--- a/tests/Unit/Countries/US/Iowa/V20200101/IowaIncomeTest.php
+++ b/tests/Unit/Countries/US/Iowa/V20200101/IowaIncomeTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Appleton\Taxes\Tests\Unit\Countries\US\Iowa\V20200101;
+
+use Appleton\Taxes\Countries\US\FederalIncome\FederalIncome;
+use Appleton\Taxes\Countries\US\Iowa\IowaIncome\IowaIncome;
+use Appleton\Taxes\Models\Countries\US\Iowa\IowaIncomeTaxInformation;
+use Appleton\Taxes\Tests\Unit\Countries\TestParameters;
+use Appleton\Taxes\Tests\Unit\Countries\TestParametersBuilder;
+use Appleton\Taxes\Tests\Unit\Countries\TaxTestCase;
+
+class IowaIncomeTest extends TaxTestCase
+{
+    private const DATE = '2020-01-01';
+    private const LOCATION = 'us.iowa';
+    private const TAX_CLASS = IowaIncome::class;
+    private const TAX_INFO_CLASS = IowaIncomeTaxInformation::class;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->query_runner->addTax(FederalIncome::class);
+        $this->query_runner->addTax(self::TAX_CLASS);
+
+        IowaIncomeTaxInformation::createForUser([
+            'additional_withholding' => 0,
+            'allowances' => 0,
+            'exempt' => false,
+        ], $this->user);
+    }
+
+    /**
+     * @dataProvider provideTestData
+     */
+    public function testTax(TestParameters $parameters): void
+    {
+        $this->validate($parameters);
+    }
+
+    public function provideTestData(): array
+    {
+        $builder = new TestParametersBuilder();
+        $builder
+            ->setDate(self::DATE)
+            ->setHomeLocation(self::LOCATION)
+            ->setTaxClass(self::TAX_CLASS)
+            ->setTaxInfoClass(self::TAX_INFO_CLASS)
+            ->setPayPeriods(52);
+
+        return [
+            '00' => [
+                $builder
+                    ->setTaxInfoOptions(['exempt' => true])
+                    ->setWagesInCents(30000)
+                    ->setExpectedAmountInCents(0)
+                    ->build()
+            ],
+            '01' => [
+                $builder
+                    ->setTaxInfoOptions(null)
+                    ->setWagesInCents(30000)
+                    ->setExpectedAmountInCents(753)
+                    ->build()
+            ],
+            '02' => [
+                $builder
+                    ->setTaxInfoOptions(['allowances' => 2])
+                    ->setWagesInCents(70000)
+                    ->setExpectedAmountInCents(2340)
+                    ->build()
+            ],
+            '03' => [
+                $builder
+                    ->setTaxInfoOptions(null)
+                    ->setWagesInCents(70000)
+                    ->setExpectedAmountInCents(2821)
+                    ->build()
+            ],
+            '04' => [
+                $builder
+                    ->setTaxInfoOptions(['additional_withholding' => 0])
+                    ->setWagesInCents(70000)
+                    ->setExpectedAmountInCents(2821)
+                    ->build()
+            ],
+            '05' => [
+                $builder
+                    ->setTaxInfoOptions(['additional_withholding' => 20])
+                    ->setWagesInCents(70000)
+                    ->setExpectedAmountInCents(4821)
+                    ->build()
+            ],
+            '06' => [
+                $builder
+                    ->setTaxInfoOptions(['additional_withholding' => 200])
+                    ->setWagesInCents(70000)
+                    ->setExpectedAmountInCents(22821)
+                    ->build()
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
refs: https://spurwork.atlassian.net/browse/LAWS-202

Summary: Iowa changed their tax amounts for allowances and the numbers in the tax brackets. The form also has additional withholding so this adds that too.