### PR TITLE
LAWS-236 Wisconsin Tax Library Updates

### DIFF
--- a/src/Countries/US/Wisconsin/WisconsinIncome/WisconsinIncome.php
+++ b/src/Countries/US/Wisconsin/WisconsinIncome/WisconsinIncome.php
@@ -8,17 +8,24 @@ use Appleton\Taxes\Models\Countries\US\Wisconsin\WisconsinIncomeTaxInformation;
 
 abstract class WisconsinIncome extends BaseStateIncome
 {
-    const FILING_SINGLE = 1;
-    const FILING_HEAD_OF_HOUSEHOLD = 2;
-    const FILING_MARRIED = 3;
-    const FILING_SEPERATE = 4;
+    const FILING_SINGLE = 0;
+    const FILING_MARRIED = 1;
 
     const FILING_STATUSES = [
-        self::FILING_SINGLE => 'FILING_SINGLE',
-        self::FILING_HEAD_OF_HOUSEHOLD => 'FILING_HEAD_OF_HOUSEHOLD',
+        self::FILING_SINGLE =>'FILING_SINGLE',
         self::FILING_MARRIED => 'FILING_MARRIED',
-        self::FILING_SEPERATE => 'FILING_SEPERATE',
     ];
+
+    const TAX_BRACKET = [
+        [0, .04, 0],
+        [10910, .0584, 436.4],
+        [21820, .0627, 1073.54],
+        [240190, .0765, 14765.34],
+    ];
+
+    const EXEMPTION_AMOUNT = 400;
+    const SINGLE_STANDARD_DEDUCTION_AMOUNT = 5730;
+    const MARRIED_STANDARD_DEDUCTION_AMOUNT = 7870;
 
     public function __construct(WisconsinIncomeTaxInformation $tax_information, Payroll $payroll)
     {

--- a/tests/Unit/Countries/US/Wisconsin/V20190101/WisconsinIncomeTest.php
+++ b/tests/Unit/Countries/US/Wisconsin/V20190101/WisconsinIncomeTest.php
@@ -50,29 +50,60 @@ class WisconsinIncomeTest extends TaxTestCase
             '00' => [
                 $builder
                     ->setTaxInfoOptions(null)
-                    ->setWagesInCents(100000)
-                    ->setExpectedAmountInCents(5686)
+                    ->setWagesInCents(10000)
+                    ->setExpectedAmountInCents(0)
                     ->build()
             ],
             '01' => [
                 $builder
-                    ->setTaxInfoOptions(['filing_status' => WisconsinIncome::FILING_MARRIED])
+                    ->setTaxInfoOptions(null)
                     ->setWagesInCents(100000)
-                    ->setExpectedAmountInCents(5492)
+                    ->setExpectedAmountInCents(5545)
                     ->build()
             ],
             '02' => [
                 $builder
-                    ->setTaxInfoOptions(['filing_status' => WisconsinIncome::FILING_SEPERATE])
-                    ->setWagesInCents(100000)
-                    ->setExpectedAmountInCents(5881)
+                    ->setTaxInfoOptions(null)
+                    ->setWagesInCents(500000)
+                    ->setExpectedAmountInCents(31309)
                     ->build()
             ],
-            'exemptions' => [
+            '03' => [
+                $builder
+                    ->setTaxInfoOptions(['filing_status' => WisconsinIncome::FILING_MARRIED])
+                    ->setWagesInCents(10000)
+                    ->setExpectedAmountInCents(0)
+                    ->build()
+            ],
+            '04' => [
+                $builder
+                    ->setTaxInfoOptions(['filing_status' => WisconsinIncome::FILING_MARRIED])
+                    ->setWagesInCents(100000)
+                    ->setExpectedAmountInCents(5493)
+                    ->build()
+            ],
+            '05' => [
+                $builder
+                    ->setTaxInfoOptions(['filing_status' => WisconsinIncome::FILING_MARRIED])
+                    ->setWagesInCents(500000)
+                    ->setExpectedAmountInCents(31309)
+                    ->build()
+            ],
+            'exemptions_single' => [
                 $builder
                     ->setTaxInfoOptions(['exemptions' => 1])
                     ->setWagesInCents(100000)
-                    ->setExpectedAmountInCents(5638)
+                    ->setExpectedAmountInCents(5497)
+                    ->build()
+            ],
+            'exemptions_married' => [
+                $builder
+                    ->setTaxInfoOptions([
+                        'filing_status' => WisconsinIncome::FILING_MARRIED,
+                        'exemptions' => 4,
+                    ])
+                    ->setWagesInCents(100000)
+                    ->setExpectedAmountInCents(5300)
                     ->build()
             ],
             'exempt true' => [
@@ -92,7 +123,7 @@ class WisconsinIncomeTest extends TaxTestCase
                         'exempt' => false,
                     ])
                     ->setWagesInCents(100000)
-                    ->setExpectedAmountInCents(5638)
+                    ->setExpectedAmountInCents(5497)
                     ->build()
             ],
         ];


### PR DESCRIPTION
refs: https://spurwork.atlassian.net/browse/LAWS-236

Summary: I am not sure how but when I double checked the Wisconsin formula on the nfc usda page it was completely different than what was there for Wisconsin. I looked at old formulas and they were not like what was there either. Best I can come up with is the wrong state formula was used.  
I confirmed the values I got with Tasie's calculations on his state and local taxes spreadsheet. 