### PR TITLE
Hotfix - LAWS-269 Update rate on the employee and employer Oregon Workers Compensations Assessment Fund

### DIFF
--- a/src/Countries/US/Oregon/WorkersCompAssessmentFund/V20200101/WorkersCompAssessmentFund.php
+++ b/src/Countries/US/Oregon/WorkersCompAssessmentFund/V20200101/WorkersCompAssessmentFund.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Collection;
 
 class WorkersCompAssessmentFund extends BaseWorkersCompAssessmentFund
 {
-    const HOURLY_RATE_MODIFIER = 1.1;
+    const HOURLY_RATE_MODIFIER = .011;
 
     public function compute(Collection $tax_areas)
     {

--- a/src/Countries/US/Oregon/WorkersCompAssessmentFundEmployer/V20200101/WorkersCompAssessmentFundEmployer.php
+++ b/src/Countries/US/Oregon/WorkersCompAssessmentFundEmployer/V20200101/WorkersCompAssessmentFundEmployer.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Collection;
 
 class WorkersCompAssessmentFundEmployer extends BaseWorkersCompAssessmentFundEmployer
 {
-    const HOURLY_RATE_MODIFIER = 1.1;
+    const HOURLY_RATE_MODIFIER = .011;
 
     public function compute(Collection $tax_areas)
     {

--- a/tests/Unit/Countries/US/Oregon/V20200101/WorkersCompAssessmentFundEmployerTest.php
+++ b/tests/Unit/Countries/US/Oregon/V20200101/WorkersCompAssessmentFundEmployerTest.php
@@ -51,8 +51,8 @@ class WorkersCompAssessmentFundEmployerTest extends TaxTestCase
                     ->setHomeLocation(self::OREGON_LOCATION)
                     ->setWorkLocation(self::OREGON_LOCATION)
                     ->setWagesInCents(1125)
-                    ->setMinutesWorked(60)
-                    ->setExpectedAmountInCents(110)
+                    ->setMinutesWorked(480) // 8 hours
+                    ->setExpectedAmountInCents(9)
                     ->build()
             ],
             '01' => [
@@ -60,8 +60,8 @@ class WorkersCompAssessmentFundEmployerTest extends TaxTestCase
                     ->setHomeLocation(self::OREGON_LOCATION)
                     ->setWorkLocation(self::OREGON_LOCATION)
                     ->setWagesInCents(1200)
-                    ->setMinutesWorked(90)
-                    ->setExpectedAmountInCents(165)
+                    ->setMinutesWorked(960) // 16 hours
+                    ->setExpectedAmountInCents(18)
                     ->build()
             ],
             '02' => [
@@ -69,8 +69,8 @@ class WorkersCompAssessmentFundEmployerTest extends TaxTestCase
                     ->setHomeLocation(self::OREGON_LOCATION)
                     ->setWorkLocation(self::OREGON_LOCATION)
                     ->setWagesInCents(1600)
-                    ->setMinutesWorked(480)
-                    ->setExpectedAmountInCents(880)
+                    ->setMinutesWorked(2400) // 40 hours
+                    ->setExpectedAmountInCents(44)
                     ->build()
             ],
         ];

--- a/tests/Unit/Countries/US/Oregon/V20200101/WorkersCompAssessmentFundTest.php
+++ b/tests/Unit/Countries/US/Oregon/V20200101/WorkersCompAssessmentFundTest.php
@@ -51,8 +51,8 @@ class WorkersCompAssessmentFundTest extends TaxTestCase
                     ->setHomeLocation(self::OREGON_LOCATION)
                     ->setWorkLocation(self::OREGON_LOCATION)
                     ->setWagesInCents(1125)
-                    ->setMinutesWorked(60)
-                    ->setExpectedAmountInCents(110)
+                    ->setMinutesWorked(480) // 8 hours
+                    ->setExpectedAmountInCents(9)
                     ->build()
             ],
             '01' => [
@@ -60,8 +60,8 @@ class WorkersCompAssessmentFundTest extends TaxTestCase
                     ->setHomeLocation(self::OREGON_LOCATION)
                     ->setWorkLocation(self::OREGON_LOCATION)
                     ->setWagesInCents(1200)
-                    ->setMinutesWorked(90)
-                    ->setExpectedAmountInCents(165)
+                    ->setMinutesWorked(960) // 16 hours
+                    ->setExpectedAmountInCents(18)
                     ->build()
             ],
             '02' => [
@@ -69,8 +69,8 @@ class WorkersCompAssessmentFundTest extends TaxTestCase
                     ->setHomeLocation(self::OREGON_LOCATION)
                     ->setWorkLocation(self::OREGON_LOCATION)
                     ->setWagesInCents(1600)
-                    ->setMinutesWorked(480)
-                    ->setExpectedAmountInCents(880)
+                    ->setMinutesWorked(2400) // 40 hours
+                    ->setExpectedAmountInCents(44)
                     ->build()
             ],
         ];


### PR DESCRIPTION
refs: https://spurwork.atlassian.net/browse/LAWS-269

Summary: When I created this I used the wrong decimal place for the hourly rate modifier. Should have been 1.1 cents for each hour which is 0.011 but I had 1.1. This is going to be hotfixed into the API.