### PR TITLE
hotfix/ACC-1141 - California - State tax not defaulting to 0 when tax deduction is a negative number for laravel taxes

### DIFF
--- a/src/Countries/US/California/CaliforniaIncome/CaliforniaIncome.php
+++ b/src/Countries/US/California/CaliforniaIncome/CaliforniaIncome.php
@@ -59,8 +59,8 @@ abstract class CaliforniaIncome extends BaseStateIncome
         $taxable_income = $earnings - $this->getEstimatedDeductionAmount()
             - $this->getStandardDeductionAmount();
 
-        $annual_tax_amount = $this->getTaxAmountFromTaxBrackets($taxable_income, $this->getTaxBrackets())
-            - $this->getExemptionAllowanceAmount();
+        $annual_tax_amount = max($this->getTaxAmountFromTaxBrackets($taxable_income, $this->getTaxBrackets())
+            - $this->getExemptionAllowanceAmount(), 0);
         $pay_period_tax_amount = $annual_tax_amount / $this->payroll->pay_periods;
 
         $this->tax_total = $this->payroll->withholdTax($pay_period_tax_amount) +

--- a/tests/Unit/Countries/US/California/V20190101/CaliforniaIncomeTest.php
+++ b/tests/Unit/Countries/US/California/V20190101/CaliforniaIncomeTest.php
@@ -6,9 +6,9 @@ use Appleton\Taxes\Countries\US\California\CaliforniaIncome\CaliforniaIncome;
 use Appleton\Taxes\Countries\US\FederalIncome\FederalIncome;
 use Appleton\Taxes\Models\Countries\US\California\CaliforniaIncomeTaxInformation;
 use Appleton\Taxes\Models\Countries\US\FederalIncomeTaxInformation;
+use Appleton\Taxes\Tests\Unit\Countries\TaxTestCase;
 use Appleton\Taxes\Tests\Unit\Countries\TestParameters;
 use Appleton\Taxes\Tests\Unit\Countries\TestParametersBuilder;
-use Appleton\Taxes\Tests\Unit\Countries\TaxTestCase;
 
 class CaliforniaIncomeTest extends TaxTestCase
 {
@@ -193,6 +193,17 @@ class CaliforniaIncomeTest extends TaxTestCase
                     ])
                     ->setWagesInCents(100000)
                     ->setExpectedAmountInCents(3787)
+                    ->build()
+            ],
+            'not enough wages' => [
+                $builder
+                    ->setTaxInfoOptions([
+                        'filing_status' => 'M',
+                        'allowances' => 8,
+                        'estimated_deductions' => 8,
+                    ])
+                    ->setWagesInCents(100000)
+                    ->setExpectedAmountInCents(0)
                     ->build()
             ],
         ];


### PR DESCRIPTION
## Ticket
[California - State tax not defaulting to 0 when tax deduction is a negative number](https://spurwork.atlassian.net/browse/ACC-1141)

## Changes
* dont allow negative tax amounts